### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2024-09-13
+
+### 🐛 Bug Fixes
+
+- Ninja not in windows runner ([#19](https://github.com/Profiidev/gravitron/pull/19))
+- No macos imports ([#23](https://github.com/Profiidev/gravitron/pull/23))
+
+### 🧪 Testing
+
+- Ecs now has tests ([#21](https://github.com/Profiidev/gravitron/pull/21))
+- Added text results as comment to pr ([#22](https://github.com/Profiidev/gravitron/pull/22))
+
+
 ## [0.1.1] - 2024-09-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "ash",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "downcast",
  "gravitron_ecs_macros",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs_macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
 
 [[package]]
 name = "orbclient"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ninja = '*'
 
 [package]
 name = "gravitron"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A GameEngine based on an ECS and Vulkan"
@@ -39,7 +39,7 @@ thiserror = "1.0.61"
 vk-shader-macros = "0.2.9"
 winit = { version = "0.30.0", features = ["wayland"] }
 gravitron_utils = { path = "./crates/gravitron_utils", version = "0.1.1" }
-gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.1.1" }
+gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.1.2" }
 
 [lib]
 

--- a/crates/gravitron_ecs/CHANGELOG.md
+++ b/crates/gravitron_ecs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2024-09-13
+
+### 🧪 Testing
+
+- Ecs now has tests ([#21](https://github.com/Profiidev/gravitron/pull/21))
+
+
 ## [0.1.1] - 2024-09-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/gravitron_ecs/Cargo.toml
+++ b/crates/gravitron_ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]
@@ -9,6 +9,6 @@ repository = "https://github.com/Profiidev/gravitron"
 description = "A simple and performant ECS for Gravitron"
 
 [dependencies]
-gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.1" }
+gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.2" }
 downcast = "0.11.0"
 

--- a/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2024-09-13
+
+### 🧪 Testing
+
+- Ecs now has tests ([#21](https://github.com/Profiidev/gravitron/pull/21))
+
+
 ## [0.1.1] - 2024-09-13
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs_macros"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]


### PR DESCRIPTION
## 🤖 New release
* `gravitron_ecs`: 0.1.1 -> 0.1.2
* `gravitron_ecs_macros`: 0.1.1 -> 0.1.2
* `gravitron`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `gravitron_ecs`
<blockquote>

## [0.1.2] - 2024-09-13

### 🧪 Testing

- Ecs now has tests ([#21](https://github.com/Profiidev/gravitron/pull/21))
</blockquote>

## `gravitron_ecs_macros`
<blockquote>

## [0.1.2] - 2024-09-13

### 🧪 Testing

- Ecs now has tests ([#21](https://github.com/Profiidev/gravitron/pull/21))
</blockquote>

## `gravitron`
<blockquote>

## [0.1.2] - 2024-09-13

### 🐛 Bug Fixes

- Ninja not in windows runner ([#19](https://github.com/Profiidev/gravitron/pull/19))
- No macos imports ([#23](https://github.com/Profiidev/gravitron/pull/23))

### 🧪 Testing

- Ecs now has tests ([#21](https://github.com/Profiidev/gravitron/pull/21))
- Added text results as comment to pr ([#22](https://github.com/Profiidev/gravitron/pull/22))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).