### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2024-10-02
+
+### 🚀 Features
+
+- [**breaking**] Ecs builder pattern for systems and resources
+- Added capability for parallel system execution
+- Added logging ([#32](https://github.com/Profiidev/gravitron/pull/32))
+- Added ecs to gravitron
+- Clear color render
+- First ecs integration
+
+### 🐛 Bug Fixes
+
+- Made debugger import feature conditional
+- Vulkan wait for idle device before destroy
+
+### 🚜 Refactor
+
+- Removed unused stuff
+- Debug is now a feature
+
+### 🧪 Testing
+
+- Added tests for macos ([#24](https://github.com/Profiidev/gravitron/pull/24))
+
+### ⚙️ Miscellaneous Tasks
+
+- Removed unneccessary dependency
+- Excluded lock file from crate
+- Updated READMEs
+- Removed cargo dist and switched to release-plz github releases
+
+
 ## [0.1.2] - 2024-09-13
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -168,9 +168,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
@@ -213,9 +213,9 @@ checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "calloop"
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
 dependencies = [
  "jobserver",
  "libc",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ash",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "downcast",
  "gravitron_ecs_macros",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs_macros"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -566,16 +566,16 @@ dependencies = [
 
 [[package]]
 name = "gravitron_utils"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "hermit-abi"
@@ -591,9 +591,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -647,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libloading"
@@ -973,9 +973,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "orbclient"
@@ -1029,9 +1032,9 @@ checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polling"
@@ -1047,6 +1050,12 @@ dependencies = [
  "tracing",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "presser"
@@ -1074,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
 ]
@@ -1119,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1131,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1142,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "roxmltree"
@@ -1300,9 +1309,9 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1362,9 +1371,9 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1973,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/gravitron_ecs", "crates/gravitron_utils"]
 
 [package]
 name = "gravitron"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A GameEngine based on an ECS and Vulkan"
@@ -22,8 +22,8 @@ gpu-allocator = "0.27.0"
 thiserror = "1.0.64"
 vk-shader-macros = "0.2.9"
 winit = { version = "0.30.0", features = ["wayland"] }
-gravitron_utils = { path = "./crates/gravitron_utils", version = "0.1.1" }
-gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.1.2" }
+gravitron_utils = { path = "./crates/gravitron_utils", version = "0.1.2" }
+gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.2.0" }
 log = "0.4.22"
 env_logger = "0.11.5"
 

--- a/crates/gravitron_ecs/CHANGELOG.md
+++ b/crates/gravitron_ecs/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2024-10-02
+
+### 🚀 Features
+
+- [**breaking**] Ecs builder pattern for systems and resources
+- *(ecs)* Create_entity in commands no returns the id
+- Added capability for parallel system execution
+- Added logging ([#32](https://github.com/Profiidev/gravitron/pull/32))
+- Added ecs to gravitron
+- Added ability to set resources after building the ecs and retriving them
+- Made UnsageWorldCell publicly available
+
+### 🐛 Bug Fixes
+
+- [**breaking**] Moved create entity to ecs builder
+
+### 🚜 Refactor
+
+- Removed builder pattern from ecs
+- Moved systemparams
+
+### 🧪 Testing
+
+- Added tests for meta
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated READMEs
+
+
 ## [0.1.2] - 2024-09-13
 
 ### 🧪 Testing

--- a/crates/gravitron_ecs/Cargo.toml
+++ b/crates/gravitron_ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]
@@ -11,7 +11,7 @@ exclude = ["CHANGELOG.md"]
 readme = "README.md"
 
 [dependencies]
-gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.2" }
-gravitron_utils = { path = "../gravitron_utils" , version = "0.1.1" }
+gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.3" }
+gravitron_utils = { path = "../gravitron_utils" , version = "0.1.2" }
 downcast = "0.11.0"
 log = "0.4.22"

--- a/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
+
 ## [0.1.2] - 2024-09-13
 
 ### 🧪 Testing

--- a/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs_macros"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]

--- a/crates/gravitron_utils/CHANGELOG.md
+++ b/crates/gravitron_utils/CHANGELOG.md
@@ -2,4 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2024-10-02
+
+### 🚀 Features
+
+- Added logging ([#32](https://github.com/Profiidev/gravitron/pull/32))
+- Added ecs to gravitron
+
+### 🐛 Bug Fixes
+
+- Removed unneccessary logging
+
+### ⚙️ Miscellaneous Tasks
+
+- Removed unneccessary dependency
+- Updated READMEs
+
+
 

--- a/crates/gravitron_utils/Cargo.toml
+++ b/crates/gravitron_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_utils"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]


### PR DESCRIPTION
## 🤖 New release
* `gravitron_ecs`: 0.1.2 -> 0.2.0
* `gravitron_ecs_macros`: 0.1.2 -> 0.1.3
* `gravitron_utils`: 0.1.1 -> 0.1.2
* `gravitron`: 0.1.2 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `gravitron_ecs`
<blockquote>

## [0.2.0] - 2024-10-02

### 🚀 Features

- [**breaking**] Ecs builder pattern for systems and resources
- *(ecs)* Create_entity in commands no returns the id
- Added capability for parallel system execution
- Added logging ([#32](https://github.com/Profiidev/gravitron/pull/32))
- Added ecs to gravitron
- Added ability to set resources after building the ecs and retriving them
- Made UnsageWorldCell publicly available

### 🐛 Bug Fixes

- [**breaking**] Moved create entity to ecs builder

### 🚜 Refactor

- Removed builder pattern from ecs
- Moved systemparams

### 🧪 Testing

- Added tests for meta

### ⚙️ Miscellaneous Tasks

- Updated READMEs
</blockquote>

## `gravitron_ecs_macros`
<blockquote>

## [0.1.2] - 2024-09-13

### 🧪 Testing

- Ecs now has tests ([#21](https://github.com/Profiidev/gravitron/pull/21))
</blockquote>

## `gravitron_utils`
<blockquote>

## [0.1.2] - 2024-10-02

### 🚀 Features

- Added logging ([#32](https://github.com/Profiidev/gravitron/pull/32))
- Added ecs to gravitron

### 🐛 Bug Fixes

- Removed unneccessary logging

### ⚙️ Miscellaneous Tasks

- Removed unneccessary dependency
- Updated READMEs
</blockquote>

## `gravitron`
<blockquote>

## [0.2.0] - 2024-10-02

### 🚀 Features

- [**breaking**] Ecs builder pattern for systems and resources
- Added capability for parallel system execution
- Added logging ([#32](https://github.com/Profiidev/gravitron/pull/32))
- Added ecs to gravitron
- Clear color render
- First ecs integration

### 🐛 Bug Fixes

- Made debugger import feature conditional
- Vulkan wait for idle device before destroy

### 🚜 Refactor

- Removed unused stuff
- Debug is now a feature

### 🧪 Testing

- Added tests for macos ([#24](https://github.com/Profiidev/gravitron/pull/24))

### ⚙️ Miscellaneous Tasks

- Removed unneccessary dependency
- Excluded lock file from crate
- Updated READMEs
- Removed cargo dist and switched to release-plz github releases
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).