### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2024-10-16
+
+### 🚀 Features
+
+- First working meshrenderer
+- Added delta time
+- Added systemstages
+- Switched to global gpu managment
+- Added Descriptor updating
+- Added BufferBlockSize for easier control
+- Indirect indexed drawing
+- Added buffermemory resize to memorymanager
+- Added simple buffer for smaller memory amount
+- Distinct types for buffers
+- Image sampler in descriptor
+- Added uvs to models
+- Added support for multiple images in one descriptor
+- Added texture loading for fragment shaders
+- Made textures working in default shader
+- Made ecs macros work in every crate
+- Added ability for including images as bytes
+
+### 🐛 Bug Fixes
+
+- Corrected roation of transfrom
+- Removed remaining code errors for buffer rework
+- Smarter instancedata sizing and worng instancedata sizing
+- Loaded correct index data
+- Memory manager not destroying fences
+- Incorrect shader mem creation
+- Insufficent memory allocation for large amount of new instances
+- Wrong copy of modified instance data
+- Wrong instance index in draw command
+- Wrong drawcmd copy
+- Wrong isntance id after mem resize
+- Wrong access using unsafe world cell
+- Exported shader macros
+
+### 🚜 Refactor
+
+- Removed old render code
+- Only compile trace logs if using debug feature
+- Moved render pass to new file
+- Moved managed buffer to seperate file
+- Made vertex shader hardcoded
+- Hardcoded default descriptor
+- Reduced camera data to one buffer
+- Unified advanced and simple buffer types into one
+- Unified buffer and image memory types
+- Combined cmd buffer and fence to transfer
+- Moved shaders to assets
+
+### ⚙️ Miscellaneous Tasks
+
+- Moved test files
+- Fixed readme and cargo toml
+
+
 ## [0.2.0] - 2024-10-02
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79faae4620f45232f599d9bc7b290f88247a0834162c4495ab2f02d60004adfb"
+checksum = "ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -213,9 +213,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 
 [[package]]
 name = "byteorder-lite"
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.24"
+version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
+checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
 dependencies = [
  "jobserver",
  "libc",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ash",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "downcast",
  "gravitron_ecs_macros",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs_macros"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "gravitron_macro_utils",
  "proc-macro2",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_utils"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "log",
 ]
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1079,12 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "orbclient"
@@ -1097,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490d3a563d3122bf7c911a59b0add9389e5ec0f5f0c3ac6b91ff235a0e6a7f90"
+checksum = "22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4"
 dependencies = [
  "ttf-parser",
 ]
@@ -1112,18 +1109,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1169,12 +1166,6 @@ dependencies = [
  "tracing",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "presser"
@@ -1543,9 +1534,9 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "ttf-parser"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
+checksum = "5902c5d130972a0000f60860bfbf46f7ca3db5391eddfedd1b8728bd9dc96c0e"
 
 [[package]]
 name = "unicode-ident"
@@ -1601,9 +1592,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1612,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -1627,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1639,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1649,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1662,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wayland-backend"
@@ -1777,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/gravitron_ecs", "crates/gravitron_macro_utils", "crates/gravi
 
 [package]
 name = "gravitron"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A GameEngine based on an ECS and Vulkan"
@@ -22,8 +22,8 @@ gpu-allocator = { version = "0.27.0", default-features = false, features = ["vul
 thiserror = "1.0.64"
 vk-shader-macros = "0.2.9"
 winit = { version = "0.30.0" }
-gravitron_utils = { path = "./crates/gravitron_utils", version = "0.1.2" }
-gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.2.0" }
+gravitron_utils = { path = "./crates/gravitron_utils", version = "0.1.3" }
+gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.3.0" }
 log = "0.4.22"
 env_logger = "0.11.5"
 image = { version = "0.25.2", default-features = false, features = ["rayon", "png"] }

--- a/crates/gravitron_ecs/CHANGELOG.md
+++ b/crates/gravitron_ecs/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2024-10-16
+
+### 🚀 Features
+
+- Added possibiliy for settings relative execution order
+- Generic as stage identifier
+
+### 🐛 Bug Fixes
+
+- Ecs storage edges correct id
+- Set componentid type correctly
+- TypeId randomly different
+- ResMut wrong acces type
+- Suboptimal system parallelization
+- Wrong access using unsafe world cell
+
+### 🚜 Refactor
+
+- Switched to typeid for components
+- Only compile trace logs if using debug feature
+
+### ⚙️ Miscellaneous Tasks
+
+- Fixed typo
+
+
 ## [0.2.0] - 2024-10-02
 
 ### 🚀 Features

--- a/crates/gravitron_ecs/Cargo.toml
+++ b/crates/gravitron_ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]
@@ -11,8 +11,8 @@ exclude = ["CHANGELOG.md"]
 readme = "README.md"
 
 [dependencies]
-gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.3" }
-gravitron_utils = { path = "../gravitron_utils" , version = "0.1.2" }
+gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.4" }
+gravitron_utils = { path = "../gravitron_utils" , version = "0.1.3" }
 downcast = "0.11.0"
 log = "0.4.22"
 

--- a/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - 2024-10-16
+
+### 🚀 Features
+
+- Made ecs macros work in every crate
+
+### 🐛 Bug Fixes
+
+- Switched to typeid and fixed collision
+
+
 
 ## [0.1.2] - 2024-09-13
 

--- a/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs_macros"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]

--- a/crates/gravitron_macro_utils/CHANGELOG.md
+++ b/crates/gravitron_macro_utils/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2024-10-16
+
+### 🚀 Features
+
+- Made ecs macros work in every crate
+- Added ability for including images as bytes
+
+### ⚙️ Miscellaneous Tasks
+
+- Fixed readme and cargo toml
+
+

--- a/crates/gravitron_utils/CHANGELOG.md
+++ b/crates/gravitron_utils/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - 2024-10-16
+
+### 🚜 Refactor
+
+- Only compile trace logs if using debug feature
+
+
 ## [0.1.2] - 2024-10-02
 
 ### 🚀 Features

--- a/crates/gravitron_utils/Cargo.toml
+++ b/crates/gravitron_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_utils"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]


### PR DESCRIPTION
## 🤖 New release
* `gravitron_ecs`: 0.2.0 -> 0.3.0 (⚠️ API breaking changes)
* `gravitron_ecs_macros`: 0.1.3 -> 0.1.4
* `gravitron_macro_utils`: 0.1.0
* `gravitron_utils`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `gravitron`: 0.2.0 -> 0.3.0 (⚠️ API breaking changes)

### ⚠️ `gravitron_ecs` breaking changes

```
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field world_cell of struct ECS, previously in file /tmp/.tmpj7ZtzQ/gravitron_ecs/src/lib.rs:25
```

### ⚠️ `gravitron` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field VulkanConfig.textures in /tmp/.tmpK6vS0C/gravitron/src/config/vulkan.rs:9
  field GraphicsPipelineConfig.geo_shader in /tmp/.tmpK6vS0C/gravitron/src/config/vulkan.rs:68
  field GraphicsPipelineConfig.frag_shader in /tmp/.tmpK6vS0C/gravitron/src/config/vulkan.rs:69
  field MeshRenderer.model_id in /tmp/.tmpK6vS0C/gravitron/src/ecs_resources/components/renderer.rs:7
  field MeshRenderer.material in /tmp/.tmpK6vS0C/gravitron/src/ecs_resources/components/renderer.rs:8

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type MeshRenderer no longer derives Debug, in /tmp/.tmpK6vS0C/gravitron/src/ecs_resources/components/renderer.rs:6

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_missing.ron

Failed in:
  enum gravitron::config::vulkan::ShaderInputVariable, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/config/vulkan.rs:156
  enum gravitron::config::vulkan::ShaderType, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/config/vulkan.rs:130

--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant DescriptorType::UniformBuffer in /tmp/.tmpK6vS0C/gravitron/src/config/vulkan.rs:132
  variant DescriptorType::StorageBuffer in /tmp/.tmpK6vS0C/gravitron/src/config/vulkan.rs:133

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_variant_added.ron

Failed in:
  variant DescriptorType:Image in /tmp/.tmpK6vS0C/gravitron/src/config/vulkan.rs:134

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/inherent_method_missing.ron

Failed in:
  GraphicsPipelineConfig::add_shader, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/config/vulkan.rs:68
  GraphicsPipelineConfig::add_input, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/config/vulkan.rs:73
  DescriptorSet::set_type, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/config/vulkan.rs:186

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/method_parameter_count_changed.ron

Failed in:
  gravitron::config::vulkan::GraphicsPipelineConfig::new now takes 1 parameters instead of 3, in /tmp/.tmpK6vS0C/gravitron/src/config/vulkan.rs:74

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/struct_missing.ron

Failed in:
  struct gravitron::config::vulkan::ShaderInputBindings, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/config/vulkan.rs:137
  struct gravitron::config::vulkan::ShaderConfig, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/config/vulkan.rs:113
  struct gravitron::config::vulkan::Descriptor, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/config/vulkan.rs:195

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field shaders of struct GraphicsPipelineConfig, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/config/vulkan.rs:49
  field input of struct GraphicsPipelineConfig, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/config/vulkan.rs:50
  field topology of struct GraphicsPipelineConfig, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/config/vulkan.rs:51
  field viewport_size of struct GraphicsPipelineConfig, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/config/vulkan.rs:52
  field x of struct MeshRenderer, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/ecs_resources/components/renderer.rs:7
  field type_ of struct DescriptorSet, previously in file /tmp/.tmpj7ZtzQ/gravitron/src/config/vulkan.rs:172
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `gravitron_ecs`
<blockquote>

## [0.3.0] - 2024-10-16

### 🚀 Features

- Added possibiliy for settings relative execution order
- Generic as stage identifier

### 🐛 Bug Fixes

- Ecs storage edges correct id
- Set componentid type correctly
- TypeId randomly different
- ResMut wrong acces type
- Suboptimal system parallelization
- Wrong access using unsafe world cell

### 🚜 Refactor

- Switched to typeid for components
- Only compile trace logs if using debug feature

### ⚙️ Miscellaneous Tasks

- Fixed typo
</blockquote>

## `gravitron_ecs_macros`
<blockquote>

## [0.1.4] - 2024-10-16

### 🚀 Features

- Made ecs macros work in every crate

### 🐛 Bug Fixes

- Switched to typeid and fixed collision
</blockquote>

## `gravitron_macro_utils`
<blockquote>

## [0.1.0] - 2024-10-16

### 🚀 Features

- Made ecs macros work in every crate
- Added ability for including images as bytes

### ⚙️ Miscellaneous Tasks

- Fixed readme and cargo toml
</blockquote>

## `gravitron_utils`
<blockquote>

## [0.1.3] - 2024-10-16

### 🚜 Refactor

- Only compile trace logs if using debug feature
</blockquote>

## `gravitron`
<blockquote>

## [0.3.0] - 2024-10-16

### 🚀 Features

- First working meshrenderer
- Added delta time
- Added systemstages
- Switched to global gpu managment
- Added Descriptor updating
- Added BufferBlockSize for easier control
- Indirect indexed drawing
- Added buffermemory resize to memorymanager
- Added simple buffer for smaller memory amount
- Distinct types for buffers
- Image sampler in descriptor
- Added uvs to models
- Added support for multiple images in one descriptor
- Added texture loading for fragment shaders
- Made textures working in default shader
- Made ecs macros work in every crate
- Added ability for including images as bytes

### 🐛 Bug Fixes

- Corrected roation of transfrom
- Removed remaining code errors for buffer rework
- Smarter instancedata sizing and worng instancedata sizing
- Loaded correct index data
- Memory manager not destroying fences
- Incorrect shader mem creation
- Insufficent memory allocation for large amount of new instances
- Wrong copy of modified instance data
- Wrong instance index in draw command
- Wrong drawcmd copy
- Wrong isntance id after mem resize
- Wrong access using unsafe world cell
- Exported shader macros

### 🚜 Refactor

- Removed old render code
- Only compile trace logs if using debug feature
- Moved render pass to new file
- Moved managed buffer to seperate file
- Made vertex shader hardcoded
- Hardcoded default descriptor
- Reduced camera data to one buffer
- Unified advanced and simple buffer types into one
- Unified buffer and image memory types
- Combined cmd buffer and fence to transfer
- Moved shaders to assets

### ⚙️ Miscellaneous Tasks

- Moved test files
- Fixed readme and cargo toml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).