### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2024-10-23
+
+### 🚀 Features
+
+- First working meshrenderer
+- Added delta time
+- Added systemstages
+- Switched to global gpu managment
+- Added Descriptor updating
+- Added BufferBlockSize for easier control
+- Indirect indexed drawing
+- Added buffermemory resize to memorymanager
+- Added simple buffer for smaller memory amount
+- Distinct types for buffers
+- Image sampler in descriptor
+- Added uvs to models
+- Added support for multiple images in one descriptor
+- Added texture loading for fragment shaders
+- Made textures working in default shader
+- Made ecs macros work in every crate
+- Added ability for including images as bytes
+
+### 🐛 Bug Fixes
+
+- Corrected roation of transfrom
+- Removed remaining code errors for buffer rework
+- Smarter instancedata sizing and worng instancedata sizing
+- Loaded correct index data
+- Memory manager not destroying fences
+- Incorrect shader mem creation
+- Insufficent memory allocation for large amount of new instances
+- Wrong copy of modified instance data
+- Wrong instance index in draw command
+- Wrong drawcmd copy
+- Wrong isntance id after mem resize
+- Wrong access using unsafe world cell
+- Exported shader macros
+- Light range
+
+### 🚜 Refactor
+
+- Removed old render code
+- Only compile trace logs if using debug feature
+- Moved render pass to new file
+- Moved managed buffer to seperate file
+- Made vertex shader hardcoded
+- Hardcoded default descriptor
+- Reduced camera data to one buffer
+- Unified advanced and simple buffer types into one
+- Unified buffer and image memory types
+- Combined cmd buffer and fence to transfer
+- Moved shaders to assets
+
+### ⚙️ Miscellaneous Tasks
+
+- Moved test files
+- Fixed readme and cargo toml
+
+
 ## [0.2.0] - 2024-10-02
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79faae4620f45232f599d9bc7b290f88247a0834162c4495ab2f02d60004adfb"
+checksum = "ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -213,9 +213,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 
 [[package]]
 name = "byteorder-lite"
@@ -225,9 +225,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "calloop"
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.24"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ash",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "downcast",
  "gravitron_ecs_macros",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs_macros"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "gravitron_macro_utils",
  "proc-macro2",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_macro_utils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "syn",
  "toml_edit",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_utils"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "log",
 ]
@@ -725,18 +725,18 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libloading"
@@ -750,13 +750,13 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.0.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.7",
 ]
 
 [[package]]
@@ -1079,27 +1079,24 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "orbclient"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166"
+checksum = "ba0b26cec2e24f08ed8bb31519a9333140a6599b867dac464bb150bdb796fd43"
 dependencies = [
  "libredox",
 ]
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490d3a563d3122bf7c911a59b0add9389e5ec0f5f0c3ac6b91ff235a0e6a7f90"
+checksum = "22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4"
 dependencies = [
  "ttf-parser",
 ]
@@ -1112,18 +1109,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1171,12 +1168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
-
-[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1263,6 +1254,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1346,18 +1346,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,9 +1543,9 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "ttf-parser"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
+checksum = "5902c5d130972a0000f60860bfbf46f7ca3db5391eddfedd1b8728bd9dc96c0e"
 
 [[package]]
 name = "unicode-ident"
@@ -1601,9 +1601,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1612,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -1627,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1639,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1649,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1662,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wayland-backend"
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2040,7 +2040,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "rustix",
  "sctk-adwaita",
  "smithay-client-toolkit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/gravitron_ecs", "crates/gravitron_macro_utils", "crates/gravi
 
 [package]
 name = "gravitron"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A GameEngine based on an ECS and Vulkan"
@@ -22,8 +22,8 @@ gpu-allocator = { version = "0.27.0", default-features = false, features = ["vul
 thiserror = "1.0.65"
 vk-shader-macros = "0.2.9"
 winit = { version = "0.30.0" }
-gravitron_utils = { path = "./crates/gravitron_utils", version = "0.1.2" }
-gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.2.0" }
+gravitron_utils = { path = "./crates/gravitron_utils", version = "0.1.3" }
+gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.3.0" }
 log = "0.4.22"
 env_logger = "0.11.5"
 image = { version = "0.25.4", default-features = false, features = ["rayon", "png"] }

--- a/crates/gravitron_ecs/CHANGELOG.md
+++ b/crates/gravitron_ecs/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2024-10-23
+
+### 🚀 Features
+
+- Added possibiliy for settings relative execution order
+- Generic as stage identifier
+
+### 🐛 Bug Fixes
+
+- Ecs storage edges correct id
+- Set componentid type correctly
+- TypeId randomly different
+- ResMut wrong acces type
+- Suboptimal system parallelization
+- Wrong access using unsafe world cell
+
+### 🚜 Refactor
+
+- Switched to typeid for components
+- Only compile trace logs if using debug feature
+
+### ⚙️ Miscellaneous Tasks
+
+- Fixed typo
+
+
 ## [0.2.0] - 2024-10-02
 
 ### 🚀 Features

--- a/crates/gravitron_ecs/Cargo.toml
+++ b/crates/gravitron_ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]
@@ -11,8 +11,8 @@ exclude = ["CHANGELOG.md"]
 readme = "README.md"
 
 [dependencies]
-gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.3" }
-gravitron_utils = { path = "../gravitron_utils" , version = "0.1.2" }
+gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.4" }
+gravitron_utils = { path = "../gravitron_utils" , version = "0.1.3" }
 downcast = "0.11.0"
 log = "0.4.22"
 

--- a/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - 2024-10-23
+
+### 🚀 Features
+
+- Made ecs macros work in every crate
+
+### 🐛 Bug Fixes
+
+- Switched to typeid and fixed collision
+
+
 
 ## [0.1.2] - 2024-09-13
 

--- a/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs_macros"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]
@@ -12,7 +12,7 @@ description = "Macros for Gravitron's ECS"
 syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-gravitron_macro_utils = { path = "../../gravitron_macro_utils", version = "0.1.0" }
+gravitron_macro_utils = { path = "../../gravitron_macro_utils", version = "0.1.1" }
 
 [lib]
 proc-macro = true

--- a/crates/gravitron_macro_utils/CHANGELOG.md
+++ b/crates/gravitron_macro_utils/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+

--- a/crates/gravitron_macro_utils/Cargo.toml
+++ b/crates/gravitron_macro_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_macro_utils"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]

--- a/crates/gravitron_utils/CHANGELOG.md
+++ b/crates/gravitron_utils/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - 2024-10-23
+
+### 🚜 Refactor
+
+- Only compile trace logs if using debug feature
+
+
 ## [0.1.2] - 2024-10-02
 
 ### 🚀 Features

--- a/crates/gravitron_utils/Cargo.toml
+++ b/crates/gravitron_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_utils"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]


### PR DESCRIPTION
## 🤖 New release
* `gravitron_ecs`: 0.2.0 -> 0.3.0 (⚠️ API breaking changes)
* `gravitron_ecs_macros`: 0.1.3 -> 0.1.4
* `gravitron_macro_utils`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `gravitron_utils`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `gravitron`: 0.2.0 -> 0.3.0 (⚠️ API breaking changes)

### ⚠️ `gravitron_ecs` breaking changes

```
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field world_cell of struct ECS, previously in file /tmp/.tmpOzpzqJ/gravitron_ecs/src/lib.rs:25
```

### ⚠️ `gravitron` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field VulkanConfig.textures in /tmp/.tmpkjZaRn/gravitron/src/config/vulkan.rs:9
  field GraphicsPipelineConfig.geo_shader in /tmp/.tmpkjZaRn/gravitron/src/config/vulkan.rs:90
  field GraphicsPipelineConfig.frag_shader in /tmp/.tmpkjZaRn/gravitron/src/config/vulkan.rs:91

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_missing.ron

Failed in:
  enum gravitron::config::vulkan::ShaderType, previously in file /tmp/.tmpOzpzqJ/gravitron/src/config/vulkan.rs:130
  enum gravitron::config::vulkan::ShaderInputVariable, previously in file /tmp/.tmpOzpzqJ/gravitron/src/config/vulkan.rs:156

--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant DescriptorType::UniformBuffer in /tmp/.tmpkjZaRn/gravitron/src/config/vulkan.rs:154
  variant DescriptorType::StorageBuffer in /tmp/.tmpkjZaRn/gravitron/src/config/vulkan.rs:155

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant DescriptorType:Image in /tmp/.tmpkjZaRn/gravitron/src/config/vulkan.rs:156

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/function_missing.ron

Failed in:
  function gravitron::ecs_resources::systems::add_systems, previously in file /tmp/.tmpOzpzqJ/gravitron/src/ecs_resources/systems/mod.rs:7

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  GraphicsPipelineConfig::add_shader, previously in file /tmp/.tmpOzpzqJ/gravitron/src/config/vulkan.rs:68
  GraphicsPipelineConfig::add_input, previously in file /tmp/.tmpOzpzqJ/gravitron/src/config/vulkan.rs:73
  DescriptorSet::set_type, previously in file /tmp/.tmpOzpzqJ/gravitron/src/config/vulkan.rs:186

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/method_parameter_count_changed.ron

Failed in:
  gravitron::config::vulkan::GraphicsPipelineConfig::new now takes 1 parameters instead of 3, in /tmp/.tmpkjZaRn/gravitron/src/config/vulkan.rs:96

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/module_missing.ron

Failed in:
  mod gravitron::ecs_resources::resources::engine_commands, previously in file /tmp/.tmpOzpzqJ/gravitron/src/ecs_resources/resources/engine_commands.rs:1
  mod gravitron::ecs_resources::components, previously in file /tmp/.tmpOzpzqJ/gravitron/src/ecs_resources/components/mod.rs:1
  mod gravitron::ecs_resources, previously in file /tmp/.tmpOzpzqJ/gravitron/src/ecs_resources/mod.rs:1
  mod gravitron::ecs_resources::systems, previously in file /tmp/.tmpOzpzqJ/gravitron/src/ecs_resources/systems/mod.rs:1
  mod gravitron::ecs_resources::resources, previously in file /tmp/.tmpOzpzqJ/gravitron/src/ecs_resources/resources/mod.rs:1
  mod gravitron::ecs_resources::components::renderer, previously in file /tmp/.tmpOzpzqJ/gravitron/src/ecs_resources/components/renderer.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_missing.ron

Failed in:
  struct gravitron::config::vulkan::ShaderInputBindings, previously in file /tmp/.tmpOzpzqJ/gravitron/src/config/vulkan.rs:137
  struct gravitron::ecs_resources::components::renderer::MeshRenderer, previously in file /tmp/.tmpOzpzqJ/gravitron/src/ecs_resources/components/renderer.rs:6
  struct gravitron::ecs_resources::resources::engine_commands::EngineCommands, previously in file /tmp/.tmpOzpzqJ/gravitron/src/ecs_resources/resources/engine_commands.rs:8
  struct gravitron::config::vulkan::Descriptor, previously in file /tmp/.tmpOzpzqJ/gravitron/src/config/vulkan.rs:195
  struct gravitron::config::vulkan::ShaderConfig, previously in file /tmp/.tmpOzpzqJ/gravitron/src/config/vulkan.rs:113

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field shaders of struct GraphicsPipelineConfig, previously in file /tmp/.tmpOzpzqJ/gravitron/src/config/vulkan.rs:49
  field input of struct GraphicsPipelineConfig, previously in file /tmp/.tmpOzpzqJ/gravitron/src/config/vulkan.rs:50
  field topology of struct GraphicsPipelineConfig, previously in file /tmp/.tmpOzpzqJ/gravitron/src/config/vulkan.rs:51
  field viewport_size of struct GraphicsPipelineConfig, previously in file /tmp/.tmpOzpzqJ/gravitron/src/config/vulkan.rs:52
  field type_ of struct DescriptorSet, previously in file /tmp/.tmpOzpzqJ/gravitron/src/config/vulkan.rs:172
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `gravitron_ecs`
<blockquote>

## [0.3.0] - 2024-10-23

### 🚀 Features

- Added possibiliy for settings relative execution order
- Generic as stage identifier

### 🐛 Bug Fixes

- Ecs storage edges correct id
- Set componentid type correctly
- TypeId randomly different
- ResMut wrong acces type
- Suboptimal system parallelization
- Wrong access using unsafe world cell

### 🚜 Refactor

- Switched to typeid for components
- Only compile trace logs if using debug feature

### ⚙️ Miscellaneous Tasks

- Fixed typo
</blockquote>

## `gravitron_ecs_macros`
<blockquote>

## [0.1.4] - 2024-10-23

### 🚀 Features

- Made ecs macros work in every crate

### 🐛 Bug Fixes

- Switched to typeid and fixed collision
</blockquote>

## `gravitron_utils`
<blockquote>

## [0.1.3] - 2024-10-23

### 🚜 Refactor

- Only compile trace logs if using debug feature
</blockquote>

## `gravitron`
<blockquote>

## [0.3.0] - 2024-10-23

### 🚀 Features

- First working meshrenderer
- Added delta time
- Added systemstages
- Switched to global gpu managment
- Added Descriptor updating
- Added BufferBlockSize for easier control
- Indirect indexed drawing
- Added buffermemory resize to memorymanager
- Added simple buffer for smaller memory amount
- Distinct types for buffers
- Image sampler in descriptor
- Added uvs to models
- Added support for multiple images in one descriptor
- Added texture loading for fragment shaders
- Made textures working in default shader
- Made ecs macros work in every crate
- Added ability for including images as bytes

### 🐛 Bug Fixes

- Corrected roation of transfrom
- Removed remaining code errors for buffer rework
- Smarter instancedata sizing and worng instancedata sizing
- Loaded correct index data
- Memory manager not destroying fences
- Incorrect shader mem creation
- Insufficent memory allocation for large amount of new instances
- Wrong copy of modified instance data
- Wrong instance index in draw command
- Wrong drawcmd copy
- Wrong isntance id after mem resize
- Wrong access using unsafe world cell
- Exported shader macros
- Light range

### 🚜 Refactor

- Removed old render code
- Only compile trace logs if using debug feature
- Moved render pass to new file
- Moved managed buffer to seperate file
- Made vertex shader hardcoded
- Hardcoded default descriptor
- Reduced camera data to one buffer
- Unified advanced and simple buffer types into one
- Unified buffer and image memory types
- Combined cmd buffer and fence to transfer
- Moved shaders to assets

### ⚙️ Miscellaneous Tasks

- Moved test files
- Fixed readme and cargo toml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).