### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2025-01-21
+
+### 🚀 Features
+
+- Defered rendering stage 2
+- Auto detect wayland
+- Added added and changed to components
+- Save comp removed tick
+- Inital hierarchy implementation
+- Added renderer crate
+- Added plugin crate
+- First plugin logic
+- Added gravitron window
+- Added window resources
+- Added input resource
+- Added engine struct
+- Added additional logging
+
+### 🐛 Bug Fixes
+
+- Wrong import of trait
+- Wrong import of trait
+- Test main wrong imports
+- Fixed some oversights in rework
+
+### 🚜 Refactor
+
+- Moved modelid to struct
+- Changed query structure
+- Removed combined ecs struct and made scheduler pub
+- Renamed type_ to r#type
+- Moved render code to crate
+- Removed some errors
+- Renderer now using window handle resource
+- Fixed imports
+
+### 📚 Documentation
+
+- Fixed readme
+
+### ⚡ Performance
+
+- Removed into_query overhead
+
+### ⚙️ Miscellaneous Tasks
+
+- Moved some dependencies to workspace
+
+
 ## [0.3.0] - 2024-10-29
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
  "ndk-context",
  "ndk-sys",
  "num_enum",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -87,9 +87,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
@@ -126,11 +126,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -277,9 +278,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -310,7 +311,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -333,9 +334,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -399,18 +400,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -424,9 +425,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
 dependencies = [
  "cc",
 ]
@@ -573,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -592,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -643,9 +644,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -682,18 +683,18 @@ dependencies = [
 
 [[package]]
 name = "fdeflate"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c6f4c64c1d33a3111c4466f7365ebdcc37c5bd1ea0d62aae2e3d722aacbedb"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -762,12 +763,12 @@ dependencies = [
  "ash",
  "log",
  "presser",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "gravitron"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "env_logger",
  "glam",
@@ -782,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "gravitron_ecs_macros",
@@ -793,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs_macros"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "gravitron_macro_utils",
  "proc-macro2",
@@ -810,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_macro_utils"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "syn",
  "toml_edit",
@@ -845,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_utils"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "log",
 ]
@@ -918,9 +919,9 @@ checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -989,7 +990,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -1011,35 +1012,35 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+checksum = "9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa"
 dependencies = [
  "arbitrary",
  "cc",
- "once_cell",
 ]
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -1119,9 +1120,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1139,7 +1140,7 @@ dependencies = [
  "ndk-sys",
  "num_enum",
  "raw-window-handle",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1566,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.17.14"
+version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f9d46a34a05a6a57566bc2bfae066ef07585a6e3fa30fbbdff5936380623f0"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
@@ -1728,7 +1729,7 @@ dependencies = [
  "rand_chacha",
  "simd_helpers",
  "system-deps",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -1818,9 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1868,6 +1869,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,18 +1910,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1923,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -2013,7 +2020,7 @@ dependencies = [
  "log",
  "memmap2",
  "rustix",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -2071,11 +2078,11 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.68",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -2089,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2202,9 +2209,9 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2271,24 +2278,24 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -2297,21 +2304,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2319,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2332,9 +2340,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wayland-backend"
@@ -2447,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2733,9 +2744,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ glam = "0.29.2"
 thiserror = "2.0.11"
 ash = "0.38.0"
 winit = { version = "0.30.8", features = ["wayland"] }
-gravitron_utils = { path = "./crates/gravitron_utils", version = "0.1.3" }
-gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.3.0" }
+gravitron_utils = { path = "./crates/gravitron_utils", version = "0.1.4" }
+gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.4.0" }
 gravitron_hierarchy = { path = "./crates/gravitron_hierarchy", version = "0.1.0" }
 gravitron_renderer = { path = "./crates/gravitron_renderer", version = "0.1.0" }
-gravitron_macro_utils = { path = "./crates/gravitron_macro_utils", version = "0.1.1" }
+gravitron_macro_utils = { path = "./crates/gravitron_macro_utils", version = "0.1.2" }
 gravitron_plugin = { path = "./crates/gravitron_plugin", version = "0.1.0" }
 gravitron_window = { path = "./crates/gravitron_window", version = "0.1.0" }
 
 [package]
 name = "gravitron"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A GameEngine based on an ECS and Vulkan"

--- a/crates/gravitron_ecs/CHANGELOG.md
+++ b/crates/gravitron_ecs/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2025-01-21
+
+### 🚀 Features
+
+- Faster hashmap
+- Added inline in ecs
+- Added added and changed to components
+- Save comp removed tick
+- Added filter to query
+- Inital hierarchy implementation
+- Added simpler way to propergate top down through hierarchy
+- Added option for changing system execution type
+
+### 🐛 Bug Fixes
+
+- Archetype res invalid
+- Fixed some oversights in rework
+
+### 🚜 Refactor
+
+- Moved id to struct
+- Moved modelid to struct
+- Changed query structure
+- Removed combined ecs struct and made scheduler pub
+- Renamed type_ to r#type
+
+### 📚 Documentation
+
+- Fixed readme
+
+### ⚡ Performance
+
+- Added some more benches
+- Removed into_query overhead
+
+### 🎨 Styling
+
+- Fixed format
+
+### 🧪 Testing
+
+- Fixed benches
+- Added query filter tests
+
+### ⚙️ Miscellaneous Tasks
+
+- Moved some dependencies to workspace
+- Fixed windows tests
+
+
 ## [0.3.0] - 2024-10-29
 
 ### 🚀 Features

--- a/crates/gravitron_ecs/Cargo.toml
+++ b/crates/gravitron_ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]
@@ -11,7 +11,7 @@ exclude = ["CHANGELOG.md"]
 readme = "README.md"
 
 [dependencies]
-gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.4" }
+gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.5" }
 gravitron_utils = { workspace = true }
 log = { workspace = true }
 rustc-hash = "2.1.0"

--- a/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.5] - 2025-01-21
+
+### 🚀 Features
+
+- Added inline in ecs
+- Added filter to query
+
+### 📚 Documentation
+
+- Fixed readme
+
+### ⚙️ Miscellaneous Tasks
+
+- Moved some dependencies to workspace
+
+
 ## [0.1.4] - 2024-10-29
 
 ### 🚀 Features

--- a/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs_macros"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]

--- a/crates/gravitron_hierarchy/CHANGELOG.md
+++ b/crates/gravitron_hierarchy/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2025-01-21
+
+### 🚀 Features
+
+- Inital hierarchy implementation
+- Added simpler way to propergate top down through hierarchy
+- Added renderer crate
+- Added additional logging
+
+### 🐛 Bug Fixes
+
+- Not removing self from parent
+- Set_parent not working
+
+### 🧪 Testing
+
+- *(hierarchy)* Added tests for remaining fns
+
+

--- a/crates/gravitron_macro_utils/CHANGELOG.md
+++ b/crates/gravitron_macro_utils/CHANGELOG.md
@@ -2,4 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2025-01-21
+
+### ⚙️ Miscellaneous Tasks
+
+- Moved some dependencies to workspace
+
+
 

--- a/crates/gravitron_macro_utils/Cargo.toml
+++ b/crates/gravitron_macro_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_macro_utils"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]

--- a/crates/gravitron_plugin/CHANGELOG.md
+++ b/crates/gravitron_plugin/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2025-01-21
+
+### 🚀 Features
+
+- Added plugin crate
+- First plugin logic
+- Added gravitron window
+- Added window resources
+- Added input resource
+- Added engine struct
+- Added additional logging
+- Added option for changing system execution type
+
+### 🐛 Bug Fixes
+
+- Fixed some oversights in rework
+
+### 🚜 Refactor
+
+- Renderer now using window handle resource
+- Fixed imports
+
+

--- a/crates/gravitron_renderer/CHANGELOG.md
+++ b/crates/gravitron_renderer/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2025-01-21
+
+### 🚀 Features
+
+- Added renderer crate
+- First plugin logic
+- Added gravitron window
+- Added window resources
+- Added input resource
+- Added engine struct
+- Added additional logging
+- Added wayland flag
+- Added option for changing system execution type
+
+### 🚜 Refactor
+
+- Moved render code to crate
+- Removed some errors
+- Renderer now using window handle resource
+- Fixed imports
+
+

--- a/crates/gravitron_utils/CHANGELOG.md
+++ b/crates/gravitron_utils/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - 2025-01-21
+
+### ⚙️ Miscellaneous Tasks
+
+- Moved some dependencies to workspace
+
+
 ## [0.1.3] - 2024-10-29
 
 ### 🚜 Refactor

--- a/crates/gravitron_utils/Cargo.toml
+++ b/crates/gravitron_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_utils"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]

--- a/crates/gravitron_window/CHANGELOG.md
+++ b/crates/gravitron_window/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2025-01-21
+
+### 🚀 Features
+
+- Added gravitron window
+- Added window resources
+- Added input resource
+- Added engine struct
+- Added additional logging
+- Added wayland flag
+
+### 🐛 Bug Fixes
+
+- Test main wrong imports
+- Fixed some oversights in rework
+
+### 🚜 Refactor
+
+- Renderer now using window handle resource
+
+


### PR DESCRIPTION
## 🤖 New release
* `gravitron_ecs`: 0.3.0 -> 0.4.0 (⚠️ API breaking changes)
* `gravitron_ecs_macros`: 0.1.4 -> 0.1.5
* `gravitron_macro_utils`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `gravitron_utils`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `gravitron_hierarchy`: 0.1.0
* `gravitron_plugin`: 0.1.0
* `gravitron_renderer`: 0.1.0
* `gravitron_window`: 0.1.0
* `gravitron`: 0.3.0 -> 0.4.0 (⚠️ API breaking changes)

### ⚠️ `gravitron_ecs` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_missing.ron

Failed in:
  enum gravitron_ecs::systems::query::ParamType, previously in file /tmp/.tmpwqXcSE/gravitron_ecs/src/systems/query.rs:175

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/method_parameter_count_changed.ron

Failed in:
  gravitron_ecs::commands::Commands::remove_comp now takes 2 parameters instead of 3, in /tmp/.tmpTIfQt0/gravitron/crates/gravitron_ecs/src/commands.rs:72

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct gravitron_ecs::ECS, previously in file /tmp/.tmpwqXcSE/gravitron_ecs/src/lib.rs:24
  struct gravitron_ecs::ECSBuilder, previously in file /tmp/.tmpwqXcSE/gravitron_ecs/src/lib.rs:29

--- failure trait_mismatched_generic_lifetimes: trait now takes a different number of generic lifetimes ---

Description:
A trait now takes a different number of generic lifetime parameters. Uses of this trait that name the previous number of parameters, such as in trait bounds, will be broken.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/trait_mismatched_generic_lifetimes.ron
Failed in:
  trait QueryParam (1 -> 0 lifetime params) in /tmp/.tmpTIfQt0/gravitron/crates/gravitron_ecs/src/systems/query/mod.rs:111
  trait QueryParamItem (1 -> 0 lifetime params) in /tmp/.tmpTIfQt0/gravitron/crates/gravitron_ecs/src/systems/query/mod.rs:195
```

### ⚠️ `gravitron` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_missing.ron

Failed in:
  enum gravitron::ecs::systems::stages::SystemStage, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/systems/stages.rs:2
  enum gravitron::vulkan::memory::types::BufferType, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/types.rs:34
  enum gravitron::config::vulkan::PipelineType, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/vulkan.rs:83
  enum gravitron::vulkan::memory::types::ImageId, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/types.rs:18
  enum gravitron::vulkan::error::RendererInitError, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/error.rs:14
  enum gravitron::vulkan::memory::types::ImageType, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/types.rs:39
  enum gravitron::vulkan::error::QueueFamilyMissingError, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/error.rs:4
  enum gravitron::vulkan::memory::types::BufferBlockSize, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/types.rs:27
  enum gravitron::vulkan::graphics::resources::model::InstanceCount, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/model/mod.rs:56
  enum gravitron::config::vulkan::DescriptorType, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/vulkan.rs:153
  enum gravitron::config::vulkan::ImageData, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/vulkan.rs:46
  enum gravitron::engine::WindowMessage, previously in file /tmp/.tmpwqXcSE/gravitron/src/engine/mod.rs:170
  enum gravitron::vulkan::memory::types::BufferId, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/types.rs:12

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/feature_missing.ron

Failed in:
  feature wayland in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/function_missing.ron

Failed in:
  function gravitron::ecs::systems::add_systems, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/systems/mod.rs:11

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/inherent_method_missing.ron

Failed in:
  GravitronBuilder::add_resource, previously in file /tmp/.tmpwqXcSE/gravitron/src/engine/mod.rs:106
  GravitronBuilder::add_system, previously in file /tmp/.tmpwqXcSE/gravitron/src/engine/mod.rs:111
  GravitronBuilder::create_entity, previously in file /tmp/.tmpwqXcSE/gravitron/src/engine/mod.rs:119

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/method_parameter_count_changed.ron

Failed in:
  gravitron::engine::GravitronBuilder::new now takes 0 parameters instead of 1, in /tmp/.tmpTIfQt0/gravitron/src/engine.rs:36
  gravitron::engine::Gravitron::builder now takes 0 parameters instead of 1, in /tmp/.tmpTIfQt0/gravitron/src/engine.rs:21

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/module_missing.ron

Failed in:
  mod gravitron::ecs::systems, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/systems/mod.rs:1
  mod gravitron::ecs::resources::engine_info, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/resources/engine_info.rs:1
  mod gravitron::vulkan::error, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/error.rs:1
  mod gravitron::vulkan::memory::types, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/types.rs:1
  mod gravitron::vulkan::graphics::resources::material, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/material.rs:1
  mod gravitron::config::vulkan, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/vulkan.rs:1
  mod gravitron::config::app, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/app.rs:1
  mod gravitron::vulkan::graphics::resources::model, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/model/mod.rs:1
  mod gravitron::ecs::resources::window, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/resources/window.rs:1
  mod gravitron::vulkan::memory::manager, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/manager.rs:1
  mod gravitron::ecs::resources::input, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/resources/input.rs:1
  mod gravitron::vulkan::graphics, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/mod.rs:1
  mod gravitron::ecs::components::transform, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/components/transform.rs:1
  mod gravitron::ecs::components::lighting, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/components/lighting.rs:1
  mod gravitron::vulkan::memory, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/mod.rs:1
  mod gravitron::vulkan, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/mod.rs:1
  mod gravitron::ecs::components::renderer, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/components/renderer.rs:1
  mod gravitron::ecs::systems::stages, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/systems/stages.rs:1
  mod gravitron::vulkan::graphics::resources, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/mod.rs:1
  mod gravitron::ecs::resources::engine_commands, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/resources/engine_commands.rs:1
  mod gravitron::ecs::components::camera, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/components/camera.rs:1
  mod gravitron::config, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/mod.rs:1
  mod gravitron::vulkan::graphics::resources::lighting, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/lighting.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  CUBE_MODEL in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/model/mod.rs:27
  BUFFER_BLOCK_SIZE_SMALL in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/types.rs:25
  BUFFER_BLOCK_SIZE_MEDIUM in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/types.rs:24
  BUFFER_BLOCK_SIZE_LARGE in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/types.rs:23

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct gravitron::ecs::resources::engine_commands::EngineCommands, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/resources/engine_commands.rs:8
  struct gravitron::vulkan::Vulkan, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/mod.rs:38
  struct gravitron::ecs::resources::window::Window, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/resources/window.rs:6
  struct gravitron::vulkan::memory::BufferMemory, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/allocator.rs:5
  struct gravitron::vulkan::graphics::resources::lighting::PointLight, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/lighting.rs:21
  struct gravitron::config::app::AppConfig, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/app.rs:1
  struct gravitron::vulkan::graphics::resources::lighting::DirectionalLight, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/lighting.rs:12
  struct gravitron::vulkan::graphics::Renderer, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/mod.rs:30
  struct gravitron::config::vulkan::ImageConfig, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/vulkan.rs:40
  struct gravitron::vulkan::memory::manager::Transfer, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/manager.rs:361
  struct gravitron::ecs::components::camera::CameraBuilder, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/components/camera.rs:7
  struct gravitron::ecs::resources::input::Input, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/resources/input.rs:6
  struct gravitron::ecs::components::lighting::DirectionalLight, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/components/lighting.rs:4
  struct gravitron::ecs::components::renderer::MeshRenderer, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/components/renderer.rs:6
  struct gravitron::vulkan::graphics::resources::material::Material, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/material.rs:1
  struct gravitron::config::vulkan::DescriptorSet, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/vulkan.rs:148
  struct gravitron::vulkan::graphics::resources::model::ModelManager, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/model/mod.rs:19
  struct gravitron::vulkan::graphics::resources::model::InstanceData, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/model/mod.rs:47
  struct gravitron::config::vulkan::ComputePipelineConfig, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/vulkan.rs:121
  struct gravitron::ecs::components::transform::Transform, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/components/transform.rs:4
  struct gravitron::ecs::resources::engine_info::EngineInfo, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/resources/engine_info.rs:2
  struct gravitron::config::vulkan::ImageDescriptor, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/vulkan.rs:209
  struct gravitron::ecs::components::camera::Camera, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/components/camera.rs:67
  struct gravitron::config::vulkan::VulkanConfig, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/vulkan.rs:6
  struct gravitron::vulkan::graphics::resources::model::VertexData, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/model/mod.rs:39
  struct gravitron::ecs::components::lighting::SpotLight, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/components/lighting.rs:19
  struct gravitron::config::EngineConfig, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/mod.rs:5
  struct gravitron::config::vulkan::RendererConfig, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/vulkan.rs:68
  struct gravitron::vulkan::graphics::resources::lighting::SpotLight, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/lighting.rs:29
  struct gravitron::vulkan::graphics::resources::lighting::LightInfo, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/lighting.rs:4
  struct gravitron::vulkan::graphics::resources::lighting::Vec3Align16, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/graphics/resources/lighting.rs:40
  struct gravitron::config::vulkan::BufferDescriptor, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/vulkan.rs:181
  struct gravitron::vulkan::memory::manager::MemoryManager, previously in file /tmp/.tmpwqXcSE/gravitron/src/vulkan/memory/manager.rs:29
  struct gravitron::ecs::components::lighting::PointLight, previously in file /tmp/.tmpwqXcSE/gravitron/src/ecs/components/lighting.rs:12
  struct gravitron::config::vulkan::GraphicsPipelineConfig, previously in file /tmp/.tmpwqXcSE/gravitron/src/config/vulkan.rs:88
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `gravitron_ecs`
<blockquote>

## [0.4.0] - 2025-01-21

### 🚀 Features

- Faster hashmap
- Added inline in ecs
- Added added and changed to components
- Save comp removed tick
- Added filter to query
- Inital hierarchy implementation
- Added simpler way to propergate top down through hierarchy
- Added option for changing system execution type

### 🐛 Bug Fixes

- Archetype res invalid
- Fixed some oversights in rework

### 🚜 Refactor

- Moved id to struct
- Moved modelid to struct
- Changed query structure
- Removed combined ecs struct and made scheduler pub
- Renamed type_ to r#type

### 📚 Documentation

- Fixed readme

### ⚡ Performance

- Added some more benches
- Removed into_query overhead

### 🎨 Styling

- Fixed format

### 🧪 Testing

- Fixed benches
- Added query filter tests

### ⚙️ Miscellaneous Tasks

- Moved some dependencies to workspace
- Fixed windows tests
</blockquote>

## `gravitron_ecs_macros`
<blockquote>

## [0.1.5] - 2025-01-21

### 🚀 Features

- Added inline in ecs
- Added filter to query

### 📚 Documentation

- Fixed readme

### ⚙️ Miscellaneous Tasks

- Moved some dependencies to workspace
</blockquote>

## `gravitron_macro_utils`
<blockquote>

## [0.1.2] - 2025-01-21

### ⚙️ Miscellaneous Tasks

- Moved some dependencies to workspace
</blockquote>

## `gravitron_utils`
<blockquote>

## [0.1.4] - 2025-01-21

### ⚙️ Miscellaneous Tasks

- Moved some dependencies to workspace
</blockquote>

## `gravitron_hierarchy`
<blockquote>

## [0.1.0] - 2025-01-21

### 🚀 Features

- Inital hierarchy implementation
- Added simpler way to propergate top down through hierarchy
- Added renderer crate
- Added additional logging

### 🐛 Bug Fixes

- Not removing self from parent
- Set_parent not working

### 🧪 Testing

- *(hierarchy)* Added tests for remaining fns
</blockquote>

## `gravitron_plugin`
<blockquote>

## [0.1.0] - 2025-01-21

### 🚀 Features

- Added plugin crate
- First plugin logic
- Added gravitron window
- Added window resources
- Added input resource
- Added engine struct
- Added additional logging
- Added option for changing system execution type

### 🐛 Bug Fixes

- Fixed some oversights in rework

### 🚜 Refactor

- Renderer now using window handle resource
- Fixed imports
</blockquote>

## `gravitron_renderer`
<blockquote>

## [0.1.0] - 2025-01-21

### 🚀 Features

- Added renderer crate
- First plugin logic
- Added gravitron window
- Added window resources
- Added input resource
- Added engine struct
- Added additional logging
- Added wayland flag
- Added option for changing system execution type

### 🚜 Refactor

- Moved render code to crate
- Removed some errors
- Renderer now using window handle resource
- Fixed imports
</blockquote>

## `gravitron_window`
<blockquote>

## [0.1.0] - 2025-01-21

### 🚀 Features

- Added gravitron window
- Added window resources
- Added input resource
- Added engine struct
- Added additional logging
- Added wayland flag

### 🐛 Bug Fixes

- Test main wrong imports
- Fixed some oversights in rework

### 🚜 Refactor

- Renderer now using window handle resource
</blockquote>

## `gravitron`
<blockquote>

## [0.4.0] - 2025-01-21

### 🚀 Features

- Defered rendering stage 2
- Auto detect wayland
- Added added and changed to components
- Save comp removed tick
- Inital hierarchy implementation
- Added renderer crate
- Added plugin crate
- First plugin logic
- Added gravitron window
- Added window resources
- Added input resource
- Added engine struct
- Added additional logging

### 🐛 Bug Fixes

- Wrong import of trait
- Wrong import of trait
- Test main wrong imports
- Fixed some oversights in rework

### 🚜 Refactor

- Moved modelid to struct
- Changed query structure
- Removed combined ecs struct and made scheduler pub
- Renamed type_ to r#type
- Moved render code to crate
- Removed some errors
- Renderer now using window handle resource
- Fixed imports

### 📚 Documentation

- Fixed readme

### ⚡ Performance

- Removed into_query overhead

### ⚙️ Miscellaneous Tasks

- Moved some dependencies to workspace
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).