### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "env_logger",
  "glam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ gravitron_window = { path = "./crates/gravitron_window", version = "0.1.0" }
 
 [package]
 name = "gravitron"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A GameEngine based on an ECS and Vulkan"


### PR DESCRIPTION
## 🤖 New release
* `gravitron_renderer`: 0.1.0
* `gravitron`: 0.3.0 -> 0.4.0 (⚠️ API breaking changes)

### ⚠️ `gravitron` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_missing.ron

Failed in:
  enum gravitron::vulkan::error::QueueFamilyMissingError, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/error.rs:4
  enum gravitron::vulkan::memory::types::ImageType, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/types.rs:39
  enum gravitron::ecs::systems::stages::SystemStage, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/systems/stages.rs:2
  enum gravitron::vulkan::memory::types::BufferBlockSize, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/types.rs:27
  enum gravitron::config::vulkan::PipelineType, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/vulkan.rs:83
  enum gravitron::engine::WindowMessage, previously in file /tmp/.tmp7Ms85q/gravitron/src/engine/mod.rs:170
  enum gravitron::vulkan::graphics::resources::model::InstanceCount, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/model/mod.rs:56
  enum gravitron::vulkan::memory::types::BufferId, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/types.rs:12
  enum gravitron::vulkan::memory::types::BufferType, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/types.rs:34
  enum gravitron::vulkan::error::RendererInitError, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/error.rs:14
  enum gravitron::vulkan::memory::types::ImageId, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/types.rs:18
  enum gravitron::config::vulkan::ImageData, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/vulkan.rs:46
  enum gravitron::config::vulkan::DescriptorType, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/vulkan.rs:153

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/feature_missing.ron

Failed in:
  feature wayland in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/function_missing.ron

Failed in:
  function gravitron::ecs::systems::add_systems, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/systems/mod.rs:11

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/inherent_method_missing.ron

Failed in:
  GravitronBuilder::add_resource, previously in file /tmp/.tmp7Ms85q/gravitron/src/engine/mod.rs:106
  GravitronBuilder::add_system, previously in file /tmp/.tmp7Ms85q/gravitron/src/engine/mod.rs:111
  GravitronBuilder::create_entity, previously in file /tmp/.tmp7Ms85q/gravitron/src/engine/mod.rs:119

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/method_parameter_count_changed.ron

Failed in:
  gravitron::engine::GravitronBuilder::new now takes 0 parameters instead of 1, in /tmp/.tmpZhRFrz/gravitron/src/engine.rs:36
  gravitron::engine::Gravitron::builder now takes 0 parameters instead of 1, in /tmp/.tmpZhRFrz/gravitron/src/engine.rs:21

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/module_missing.ron

Failed in:
  mod gravitron::vulkan::graphics::resources::model, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/model/mod.rs:1
  mod gravitron::vulkan::memory, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/mod.rs:1
  mod gravitron::vulkan::graphics, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/mod.rs:1
  mod gravitron::ecs::components::lighting, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/components/lighting.rs:1
  mod gravitron::vulkan::memory::manager, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/manager.rs:1
  mod gravitron::ecs::systems, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/systems/mod.rs:1
  mod gravitron::ecs::components::camera, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/components/camera.rs:1
  mod gravitron::ecs::components::renderer, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/components/renderer.rs:1
  mod gravitron::vulkan, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/mod.rs:1
  mod gravitron::vulkan::error, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/error.rs:1
  mod gravitron::vulkan::graphics::resources::material, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/material.rs:1
  mod gravitron::ecs::resources::window, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/resources/window.rs:1
  mod gravitron::config::vulkan, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/vulkan.rs:1
  mod gravitron::config::app, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/app.rs:1
  mod gravitron::ecs::resources::input, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/resources/input.rs:1
  mod gravitron::vulkan::memory::types, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/types.rs:1
  mod gravitron::ecs::resources::engine_info, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/resources/engine_info.rs:1
  mod gravitron::ecs::resources::engine_commands, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/resources/engine_commands.rs:1
  mod gravitron::ecs::components::transform, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/components/transform.rs:1
  mod gravitron::vulkan::graphics::resources, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/mod.rs:1
  mod gravitron::ecs::systems::stages, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/systems/stages.rs:1
  mod gravitron::vulkan::graphics::resources::lighting, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/lighting.rs:1
  mod gravitron::config, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/mod.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  BUFFER_BLOCK_SIZE_MEDIUM in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/types.rs:24
  CUBE_MODEL in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/model/mod.rs:27
  BUFFER_BLOCK_SIZE_SMALL in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/types.rs:25
  BUFFER_BLOCK_SIZE_LARGE in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/types.rs:23

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct gravitron::ecs::components::camera::CameraBuilder, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/components/camera.rs:7
  struct gravitron::vulkan::graphics::resources::model::ModelManager, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/model/mod.rs:19
  struct gravitron::config::vulkan::BufferDescriptor, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/vulkan.rs:181
  struct gravitron::ecs::resources::window::Window, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/resources/window.rs:6
  struct gravitron::vulkan::graphics::resources::lighting::DirectionalLight, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/lighting.rs:12
  struct gravitron::vulkan::graphics::resources::lighting::Vec3Align16, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/lighting.rs:40
  struct gravitron::ecs::components::renderer::MeshRenderer, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/components/renderer.rs:6
  struct gravitron::vulkan::Vulkan, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/mod.rs:38
  struct gravitron::vulkan::graphics::resources::lighting::SpotLight, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/lighting.rs:29
  struct gravitron::vulkan::graphics::resources::model::InstanceData, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/model/mod.rs:47
  struct gravitron::vulkan::graphics::Renderer, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/mod.rs:30
  struct gravitron::vulkan::memory::BufferMemory, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/allocator.rs:5
  struct gravitron::ecs::resources::engine_commands::EngineCommands, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/resources/engine_commands.rs:8
  struct gravitron::ecs::components::lighting::DirectionalLight, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/components/lighting.rs:4
  struct gravitron::config::vulkan::ImageConfig, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/vulkan.rs:40
  struct gravitron::config::vulkan::ImageDescriptor, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/vulkan.rs:209
  struct gravitron::vulkan::memory::manager::Transfer, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/manager.rs:361
  struct gravitron::ecs::components::transform::Transform, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/components/transform.rs:4
  struct gravitron::vulkan::graphics::resources::model::VertexData, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/model/mod.rs:39
  struct gravitron::ecs::components::lighting::PointLight, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/components/lighting.rs:12
  struct gravitron::ecs::resources::engine_info::EngineInfo, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/resources/engine_info.rs:2
  struct gravitron::ecs::components::camera::Camera, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/components/camera.rs:67
  struct gravitron::config::app::AppConfig, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/app.rs:1
  struct gravitron::config::vulkan::RendererConfig, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/vulkan.rs:68
  struct gravitron::config::vulkan::ComputePipelineConfig, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/vulkan.rs:121
  struct gravitron::ecs::components::lighting::SpotLight, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/components/lighting.rs:19
  struct gravitron::config::vulkan::GraphicsPipelineConfig, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/vulkan.rs:88
  struct gravitron::vulkan::graphics::resources::material::Material, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/material.rs:1
  struct gravitron::config::vulkan::VulkanConfig, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/vulkan.rs:6
  struct gravitron::vulkan::graphics::resources::lighting::LightInfo, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/lighting.rs:4
  struct gravitron::config::vulkan::DescriptorSet, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/vulkan.rs:148
  struct gravitron::config::EngineConfig, previously in file /tmp/.tmp7Ms85q/gravitron/src/config/mod.rs:5
  struct gravitron::vulkan::graphics::resources::lighting::PointLight, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/graphics/resources/lighting.rs:21
  struct gravitron::ecs::resources::input::Input, previously in file /tmp/.tmp7Ms85q/gravitron/src/ecs/resources/input.rs:6
  struct gravitron::vulkan::memory::manager::MemoryManager, previously in file /tmp/.tmp7Ms85q/gravitron/src/vulkan/memory/manager.rs:29
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `gravitron_renderer`
<blockquote>

## [0.1.0] - 2025-01-21

### 🚀 Features

- Added renderer crate
- First plugin logic
- Added gravitron window
- Added window resources
- Added input resource
- Added engine struct
- Added additional logging
- Added wayland flag
- Added option for changing system execution type

### 🚜 Refactor

- Moved render code to crate
- Removed some errors
- Renderer now using window handle resource
- Fixed imports
</blockquote>

## `gravitron`
<blockquote>

## [0.4.0] - 2025-01-21

### 🚀 Features

- Defered rendering stage 2
- Auto detect wayland
- Added added and changed to components
- Save comp removed tick
- Inital hierarchy implementation
- Added renderer crate
- Added plugin crate
- First plugin logic
- Added gravitron window
- Added window resources
- Added input resource
- Added engine struct
- Added additional logging

### 🐛 Bug Fixes

- Wrong import of trait
- Wrong import of trait
- Test main wrong imports
- Fixed some oversights in rework

### 🚜 Refactor

- Moved modelid to struct
- Changed query structure
- Removed combined ecs struct and made scheduler pub
- Renamed type_ to r#type
- Moved render code to crate
- Removed some errors
- Renderer now using window handle resource
- Fixed imports

### 📚 Documentation

- Fixed readme

### ⚡ Performance

- Removed into_query overhead

### ⚙️ Miscellaneous Tasks

- Moved some dependencies to workspace
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).