### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2025-03-06
+
+### 🚀 Features
+
+- Added global transform
+- Made buffer memory copy and clone
+- Added config system
+
+### 🐛 Bug Fixes
+
+- Plugin cleanup not being called
+
+### 🚜 Refactor
+
+- Moved general components to own crate
+- Added back texture adding
+- Renamed ids to handles
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated test main
+
+
 ## [0.4.0] - 2025-01-21
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cc",
  "cesu8",
  "jni",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arbitrary"
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e335041290c43101ca215eed6f43ec437eb5a42125573f600fc3fa42b9bddd62"
+checksum = "98922d6a4cfbcb08820c69d8eeccc05bb1f29bfa06b4f5b1dbfe9a868bd7608e"
 dependencies = [
  "arrayvec",
 ]
@@ -239,9 +239,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitstream-io"
@@ -266,21 +266,21 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder"
@@ -296,9 +296,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "calloop"
@@ -306,7 +306,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "log",
  "polling",
  "rustix",
@@ -334,9 +334,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -400,18 +400,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -425,9 +425,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.52"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
@@ -599,9 +599,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "cursor-icon"
@@ -638,9 +638,9 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "env_logger",
  "glam",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "gravitron_ecs_macros",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs_macros"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "gravitron_macro_utils",
  "proc-macro2",
@@ -815,14 +815,14 @@ dependencies = [
 
 [[package]]
 name = "gravitron_hierarchy"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "gravitron_ecs",
 ]
 
 [[package]]
 name = "gravitron_macro_utils"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "syn",
  "toml_edit",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_plugin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "gravitron_ecs",
  "log",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_renderer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ash",
@@ -852,20 +852,20 @@ dependencies = [
  "gravitron_window",
  "image",
  "log",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "vk-shader-macros",
 ]
 
 [[package]]
 name = "gravitron_utils"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "gravitron_window"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "gravitron_ecs",
@@ -952,13 +952,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -1034,15 +1034,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa"
+checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
 dependencies = [
  "arbitrary",
  "cc",
@@ -1064,9 +1064,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.10",
 ]
 
 [[package]]
@@ -1132,9 +1132,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1146,7 +1146,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -1294,7 +1294,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "libc",
  "objc2",
@@ -1310,7 +1310,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-core-location",
@@ -1334,7 +1334,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -1366,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
@@ -1376,7 +1376,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "dispatch",
  "libc",
@@ -1401,7 +1401,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -1413,7 +1413,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -1436,7 +1436,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -1468,7 +1468,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-core-location",
@@ -1477,9 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "oorandom"
@@ -1519,18 +1519,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1545,9 +1545,9 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -1631,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -1665,9 +1665,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
 dependencies = [
  "memchr",
 ]
@@ -1810,11 +1810,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1869,11 +1869,11 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1882,15 +1882,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1922,18 +1922,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1942,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -2014,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -2024,7 +2024,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -2060,9 +2060,9 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2099,11 +2099,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2119,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2165,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2221,9 +2221,9 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2361,9 +2361,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
+checksum = "b7208998eaa3870dad37ec8836979581506e0c5c64c20c9e79e9d2a10d6f47bf"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -2375,11 +2375,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.7"
+version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
+checksum = "c2120de3d33638aaef5b9f4472bff75f07c56379cf76ea320bd3a3d65ecaf73f"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -2391,16 +2391,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cursor-icon",
  "wayland-backend",
 ]
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.7"
+version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b08bc3aafdb0035e7fe0fdf17ba0c09c268732707dca4ae098f60cb28c9e4c"
+checksum = "a93029cbb6650748881a00e4922b076092a6a08c11e7fbdb923f064b23968c5d"
 dependencies = [
  "rustix",
  "wayland-client",
@@ -2409,11 +2409,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.5"
+version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd0ade57c4e6e9a8952741325c30bf82f4246885dca8bf561898b86d0c1f58e"
+checksum = "0781cf46869b37e36928f7b432273c0995aa8aed9552c556fb18754420541efc"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -2421,11 +2421,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b31cab548ee68c7eb155517f2212049dc151f7cd7910c2b66abfd31c3ee12bd"
+checksum = "7ccaacc76703fefd6763022ac565b590fcade92202492381c95b2edfdf7d46b3"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -2434,11 +2434,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782e12f6cd923c3c316130d56205ebab53f55d6666b7faddfad36cecaeeb4022"
+checksum = "248a02e6f595aad796561fa82d25601bd2c8c3b145b1c7453fc8f94c1a58f8b2"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -2447,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.5"
+version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
+checksum = "896fdafd5d28145fce7958917d69f2fd44469b1d4e861cb5961bcbeebc6d1484"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -2458,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.5"
+version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09"
+checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
 dependencies = [
  "dlib",
  "log",
@@ -2711,7 +2711,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "bytemuck",
  "calloop",
@@ -2756,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]
@@ -2807,7 +2807,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "dlib",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,18 @@ glam = "0.29.2"
 thiserror = "2.0.11"
 ash = "0.38.0"
 winit = { version = "0.30.9", features = ["wayland"] }
-gravitron_utils = { path = "./crates/gravitron_utils", version = "0.1.4" }
-gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.4.0" }
-gravitron_hierarchy = { path = "./crates/gravitron_hierarchy", version = "0.1.0" }
-gravitron_renderer = { path = "./crates/gravitron_renderer", version = "0.1.0" }
-gravitron_macro_utils = { path = "./crates/gravitron_macro_utils", version = "0.1.2" }
-gravitron_plugin = { path = "./crates/gravitron_plugin", version = "0.1.0" }
-gravitron_window = { path = "./crates/gravitron_window", version = "0.1.0" }
+gravitron_utils = { path = "./crates/gravitron_utils", version = "0.1.5" }
+gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.4.1" }
+gravitron_hierarchy = { path = "./crates/gravitron_hierarchy", version = "0.2.0" }
+gravitron_renderer = { path = "./crates/gravitron_renderer", version = "0.2.0" }
+gravitron_macro_utils = { path = "./crates/gravitron_macro_utils", version = "0.1.3" }
+gravitron_plugin = { path = "./crates/gravitron_plugin", version = "0.2.0" }
+gravitron_window = { path = "./crates/gravitron_window", version = "0.1.1" }
 gravitron_components = { path = "./crates/gravitron_components", version = "0.1.0" }
 
 [package]
 name = "gravitron"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A GameEngine based on an ECS and Vulkan"

--- a/crates/gravitron_components/CHANGELOG.md
+++ b/crates/gravitron_components/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2025-03-06
+
+### 🚜 Refactor
+
+- Moved general components to own crate
+
+

--- a/crates/gravitron_ecs/CHANGELOG.md
+++ b/crates/gravitron_ecs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] - 2025-03-06
+
+### 🚀 Features
+
+- Added global transform
+
+
 ## [0.4.0] - 2025-01-21
 
 ### 🚀 Features

--- a/crates/gravitron_ecs/Cargo.toml
+++ b/crates/gravitron_ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]
@@ -11,7 +11,7 @@ exclude = ["CHANGELOG.md"]
 readme = "README.md"
 
 [dependencies]
-gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.5" }
+gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.6" }
 gravitron_utils = { workspace = true }
 log = { workspace = true }
 rustc-hash = "2.1.1"

--- a/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.6] - 2025-03-06
+
+### ⚙️ Miscellaneous Tasks
+
+- Update Cargo.toml dependencies
+
+
 ## [0.1.5] - 2025-01-21
 
 ### 🚀 Features

--- a/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs_macros"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]

--- a/crates/gravitron_hierarchy/CHANGELOG.md
+++ b/crates/gravitron_hierarchy/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2025-03-06
+
+### 🚀 Features
+
+- Simplified propagation query and added an update only variant
+
+### 🐛 Bug Fixes
+
+- Propagation query not updating entities without children
+
+### 🧪 Testing
+
+- *(hierarchy)* Fixed tests
+
+
 ## [0.1.0] - 2025-01-21
 
 ### 🚀 Features

--- a/crates/gravitron_hierarchy/Cargo.toml
+++ b/crates/gravitron_hierarchy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_hierarchy"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]

--- a/crates/gravitron_macro_utils/CHANGELOG.md
+++ b/crates/gravitron_macro_utils/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
+
 ## [0.1.2] - 2025-01-21
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/gravitron_macro_utils/Cargo.toml
+++ b/crates/gravitron_macro_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_macro_utils"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]

--- a/crates/gravitron_plugin/CHANGELOG.md
+++ b/crates/gravitron_plugin/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2025-03-06
+
+### 🚀 Features
+
+- Added plugin dependencies
+- Added config system
+
+### 🐛 Bug Fixes
+
+- Plugin cleanup not being called
+- Tick not updated
+- Test main errors
+- Descriptor updates invalid
+
+### 🚜 Refactor
+
+- Removed unused parts of vulkan config
+
+### ⚙️ Miscellaneous Tasks
+
+- Added some more logging
+
+
 ## [0.1.0] - 2025-01-21
 
 ### 🚀 Features

--- a/crates/gravitron_plugin/Cargo.toml
+++ b/crates/gravitron_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_plugin"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]

--- a/crates/gravitron_renderer/CHANGELOG.md
+++ b/crates/gravitron_renderer/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2025-03-06
+
+### 🚀 Features
+
+- Added global transform
+- Added plugin dependencies
+- Added model manager resource
+- Added inline
+- Added descriptor rewrite
+- Made buffer memory copy and clone
+- Added config system
+- Added renderer logging
+
+### 🐛 Bug Fixes
+
+- Plugin cleanup not being called
+- Fixed pipeline imports
+- Removed warnings
+- Combined default descriptor sets
+- Added command buffer rerecording
+- Added unused
+- Test main errors
+- Removed vulkan errors
+- Added subpass dependencies
+- Nothing rendering
+- Descriptor wrong binding
+- Removed cache bypass
+- Descriptor updates invalid
+- Descriptor updates every frame
+- Simple buffer resize not working
+
+### 🚜 Refactor
+
+- Removed matrix from transform
+- Moved general components to own crate
+- Made memory manager return type result
+- Separated vulkan resources
+- Moved model code out of graphics
+- Moved renderer
+- Added descriptor manager and graphics pipeline
+- Updated pipeline manager
+- Updated renderer
+- Added all resources to plugin
+- Removed unused allow
+- Added lights update
+- Added back texture adding
+- Renamed ids to handles
+
+### 🎨 Styling
+
+- Fixed format
+
+
 ## [0.1.0] - 2025-01-21
 
 ### 🚀 Features

--- a/crates/gravitron_renderer/Cargo.toml
+++ b/crates/gravitron_renderer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_renderer"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]

--- a/crates/gravitron_utils/CHANGELOG.md
+++ b/crates/gravitron_utils/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.5] - 2025-03-06
+
+### ⚙️ Miscellaneous Tasks
+
+- Update Cargo.toml dependencies
+
+
 ## [0.1.4] - 2025-01-21
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/gravitron_utils/Cargo.toml
+++ b/crates/gravitron_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_utils"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]

--- a/crates/gravitron_window/CHANGELOG.md
+++ b/crates/gravitron_window/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2025-03-06
+
+### 🚀 Features
+
+- Added global transform
+- Added config system
+
+### ⚙️ Miscellaneous Tasks
+
+- Added some more logging
+
+
 ## [0.1.0] - 2025-01-21
 
 ### 🚀 Features

--- a/crates/gravitron_window/Cargo.toml
+++ b/crates/gravitron_window/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_window"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]


### PR DESCRIPTION



## 🤖 New release

* `gravitron_macro_utils`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `gravitron_ecs_macros`: 0.1.5 -> 0.1.6
* `gravitron_utils`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `gravitron_ecs`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `gravitron_hierarchy`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `gravitron_plugin`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `gravitron_components`: 0.1.0
* `gravitron_window`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `gravitron_renderer`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `gravitron`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `gravitron_hierarchy` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/method_parameter_count_changed.ron

Failed in:
  gravitron_hierarchy::propagation::PropagationQuery::propagate now takes 2 parameters instead of 6, in /tmp/.tmp1VCAzF/gravitron/crates/gravitron_hierarchy/src/propagation.rs:41

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  gravitron_hierarchy::propagation::PropagationQuery::propagate takes 0 generic types instead of 4, in /tmp/.tmp1VCAzF/gravitron/crates/gravitron_hierarchy/src/propagation.rs:41
```

### ⚠ `gravitron_plugin` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AppConfig.version in /tmp/.tmp1VCAzF/gravitron/crates/gravitron_plugin/src/config.rs:2
  field AppConfig.fps in /tmp/.tmp1VCAzF/gravitron/crates/gravitron_plugin/src/config.rs:3
  field AppConfig.parallel_systems in /tmp/.tmp1VCAzF/gravitron/crates/gravitron_plugin/src/config.rs:4

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_missing.ron

Failed in:
  enum gravitron_plugin::config::vulkan::DescriptorType, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/vulkan.rs:155
  enum gravitron_plugin::config::vulkan::PipelineType, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/vulkan.rs:83
  enum gravitron_plugin::config::vulkan::ImageData, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/vulkan.rs:46

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant MainSystemStage::RenderRecording 2 -> 3 in /tmp/.tmp1VCAzF/gravitron/crates/gravitron_plugin/src/stages.rs:6
  variant MainSystemStage::RenderExecute 3 -> 4 in /tmp/.tmp1VCAzF/gravitron/crates/gravitron_plugin/src/stages.rs:7
  variant MainSystemStage::PostRender 4 -> 5 in /tmp/.tmp1VCAzF/gravitron/crates/gravitron_plugin/src/stages.rs:8

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_variant_added.ron

Failed in:
  variant MainSystemStage:RenderPrepare in /tmp/.tmp1VCAzF/gravitron/crates/gravitron_plugin/src/stages.rs:5

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/inherent_method_missing.ron

Failed in:
  AppConfig::set_window_config, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/mod.rs:16
  AppConfig::set_vulkan_config, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/mod.rs:21
  AppConfig::set_engine_config, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/mod.rs:26
  PluginManager::run, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/manager.rs:45

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  gravitron_plugin::app::AppBuilder::config takes 1 generic types instead of 0, in /tmp/.tmp1VCAzF/gravitron/crates/gravitron_plugin/src/app.rs:179
  gravitron_plugin::app::AppBuilder::config_mut takes 1 generic types instead of 0, in /tmp/.tmp1VCAzF/gravitron/crates/gravitron_plugin/src/app.rs:208

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/module_missing.ron

Failed in:
  mod gravitron_plugin::config::window, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/window.rs:1
  mod gravitron_plugin::config::vulkan, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/vulkan.rs:1
  mod gravitron_plugin::config::engine, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/engine.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_missing.ron

Failed in:
  struct gravitron_plugin::config::vulkan::BufferDescriptor, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/vulkan.rs:183
  struct gravitron_plugin::config::vulkan::DescriptorSet, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/vulkan.rs:150
  struct gravitron_plugin::config::vulkan::ImageDescriptor, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/vulkan.rs:211
  struct gravitron_plugin::config::vulkan::GraphicsPipelineConfig, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/vulkan.rs:89
  struct gravitron_plugin::config::window::WindowConfig, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/window.rs:2
  struct gravitron_plugin::config::engine::EngineConfig, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/engine.rs:1
  struct gravitron_plugin::config::vulkan::RendererConfig, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/vulkan.rs:68
  struct gravitron_plugin::config::vulkan::VulkanConfig, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/vulkan.rs:6
  struct gravitron_plugin::config::vulkan::ImageConfig, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/vulkan.rs:40
  struct gravitron_plugin::config::vulkan::ComputePipelineConfig, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/vulkan.rs:123

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field window of struct AppConfig, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/mod.rs:10
  field vulkan of struct AppConfig, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/mod.rs:11
  field engine of struct AppConfig, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/config/mod.rs:12

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/trait_method_missing.ron

Failed in:
  method name of trait Plugin, previously in file /tmp/.tmpWDPjsk/gravitron_plugin/src/lib.rs:13
```

### ⚠ `gravitron_renderer` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_missing.ron

Failed in:
  enum gravitron_renderer::memory::types::BufferBlockSize, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/types.rs:25
  enum gravitron_renderer::memory::types::BufferType, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/types.rs:32
  enum gravitron_renderer::memory::types::ImageType, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/types.rs:37
  enum gravitron_renderer::memory::types::ImageId, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/types.rs:16
  enum gravitron_renderer::memory::types::BufferId, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/types.rs:10
  enum gravitron_renderer::error::RendererInitError, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/error.rs:14
  enum gravitron_renderer::graphics::resources::model::InstanceCount, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/model/mod.rs:57
  enum gravitron_renderer::error::QueueFamilyMissingError, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/error.rs:4

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/method_parameter_count_changed.ron

Failed in:
  gravitron_renderer::ecs::components::camera::CameraBuilder::build now takes 1 parameters instead of 2, in /tmp/.tmp1VCAzF/gravitron/crates/gravitron_renderer/src/ecs/components/camera.rs:43

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/module_missing.ron

Failed in:
  mod gravitron_renderer::graphics::resources::model, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/model/mod.rs:1
  mod gravitron_renderer::graphics::resources::material, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/material.rs:1
  mod gravitron_renderer::graphics::resources::lighting, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/lighting.rs:1
  mod gravitron_renderer::memory::manager, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/manager.rs:1
  mod gravitron_renderer::error, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/error.rs:1
  mod gravitron_renderer::memory, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/mod.rs:1
  mod gravitron_renderer::memory::types, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/types.rs:1
  mod gravitron_renderer::graphics::swapchain, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/swapchain.rs:1
  mod gravitron_renderer::graphics, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/mod.rs:1
  mod gravitron_renderer::ecs::resources::vulkan, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/ecs/resources/vulkan.rs:1
  mod gravitron_renderer::ecs::components::transform, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/ecs/components/transform.rs:1
  mod gravitron_renderer::graphics::resources, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/mod.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  BUFFER_BLOCK_SIZE_SMALL in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/types.rs:23
  CUBE_MODEL in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/model/mod.rs:24
  IMAGES_PER_FRAME_BUFFER in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/swapchain.rs:15
  PLANE_MODEL in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/model/mod.rs:25
  BUFFER_BLOCK_SIZE_LARGE in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/types.rs:21
  BUFFER_BLOCK_SIZE_MEDIUM in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/types.rs:22

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_missing.ron

Failed in:
  struct gravitron_renderer::graphics::resources::lighting::LightInfo, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/lighting.rs:4
  struct gravitron_renderer::memory::manager::Transfer, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/manager.rs:382
  struct gravitron_renderer::ecs::components::transform::Transform, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/ecs/components/transform.rs:4
  struct gravitron_renderer::graphics::resources::material::Material, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/material.rs:1
  struct gravitron_renderer::graphics::resources::model::ModelManager, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/model/mod.rs:16
  struct gravitron_renderer::graphics::resources::lighting::PointLight, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/lighting.rs:21
  struct gravitron_renderer::memory::manager::MemoryManager, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/manager.rs:26
  struct gravitron_renderer::graphics::resources::lighting::DirectionalLight, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/lighting.rs:12
  struct gravitron_renderer::graphics::Renderer, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/mod.rs:30
  struct gravitron_renderer::graphics::resources::lighting::SpotLight, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/lighting.rs:29
  struct gravitron_renderer::graphics::swapchain::SwapChain, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/swapchain.rs:17
  struct gravitron_renderer::memory::BufferMemory, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/memory/allocator.rs:5
  struct gravitron_renderer::graphics::resources::model::VertexData, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/model/mod.rs:40
  struct gravitron_renderer::graphics::resources::model::ModelId, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/model/mod.rs:28
  struct gravitron_renderer::graphics::resources::model::InstanceData, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/model/mod.rs:48
  struct gravitron_renderer::graphics::resources::model::Model, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/model/mod.rs:30
  struct gravitron_renderer::ecs::resources::vulkan::Vulkan, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/ecs/resources/vulkan.rs:24
  struct gravitron_renderer::graphics::resources::lighting::Vec3Align16, previously in file /tmp/.tmpWDPjsk/gravitron_renderer/src/graphics/resources/lighting.rs:40
```

### ⚠ `gravitron` breaking changes

```text
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/module_missing.ron

Failed in:
  mod gravitron::ecs::resources, previously in file /tmp/.tmpWDPjsk/gravitron/src/ecs/resources.rs:1
  mod gravitron::renderer, previously in file /tmp/.tmpWDPjsk/gravitron/src/lib.rs:11
  mod gravitron::ecs::components, previously in file /tmp/.tmpWDPjsk/gravitron/src/ecs/components.rs:1
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `gravitron_macro_utils`

<blockquote>

## [0.1.2] - 2025-01-21

### ⚙️ Miscellaneous Tasks

- Moved some dependencies to workspace
</blockquote>

## `gravitron_ecs_macros`

<blockquote>

## [0.1.6] - 2025-03-06

### ⚙️ Miscellaneous Tasks

- Update Cargo.toml dependencies
</blockquote>

## `gravitron_utils`

<blockquote>

## [0.1.5] - 2025-03-06

### ⚙️ Miscellaneous Tasks

- Update Cargo.toml dependencies
</blockquote>

## `gravitron_ecs`

<blockquote>

## [0.4.1] - 2025-03-06

### 🚀 Features

- Added global transform
</blockquote>

## `gravitron_hierarchy`

<blockquote>

## [0.2.0] - 2025-03-06

### 🚀 Features

- Simplified propagation query and added an update only variant

### 🐛 Bug Fixes

- Propagation query not updating entities without children

### 🧪 Testing

- *(hierarchy)* Fixed tests
</blockquote>

## `gravitron_plugin`

<blockquote>

## [0.2.0] - 2025-03-06

### 🚀 Features

- Added plugin dependencies
- Added config system

### 🐛 Bug Fixes

- Plugin cleanup not being called
- Tick not updated
- Test main errors
- Descriptor updates invalid

### 🚜 Refactor

- Removed unused parts of vulkan config

### ⚙️ Miscellaneous Tasks

- Added some more logging
</blockquote>

## `gravitron_components`

<blockquote>

## [0.1.0] - 2025-03-06

### 🚜 Refactor

- Moved general components to own crate
</blockquote>

## `gravitron_window`

<blockquote>

## [0.1.1] - 2025-03-06

### 🚀 Features

- Added global transform
- Added config system

### ⚙️ Miscellaneous Tasks

- Added some more logging
</blockquote>

## `gravitron_renderer`

<blockquote>

## [0.2.0] - 2025-03-06

### 🚀 Features

- Added global transform
- Added plugin dependencies
- Added model manager resource
- Added inline
- Added descriptor rewrite
- Made buffer memory copy and clone
- Added config system
- Added renderer logging

### 🐛 Bug Fixes

- Plugin cleanup not being called
- Fixed pipeline imports
- Removed warnings
- Combined default descriptor sets
- Added command buffer rerecording
- Added unused
- Test main errors
- Removed vulkan errors
- Added subpass dependencies
- Nothing rendering
- Descriptor wrong binding
- Removed cache bypass
- Descriptor updates invalid
- Descriptor updates every frame
- Simple buffer resize not working

### 🚜 Refactor

- Removed matrix from transform
- Moved general components to own crate
- Made memory manager return type result
- Separated vulkan resources
- Moved model code out of graphics
- Moved renderer
- Added descriptor manager and graphics pipeline
- Updated pipeline manager
- Updated renderer
- Added all resources to plugin
- Removed unused allow
- Added lights update
- Added back texture adding
- Renamed ids to handles

### 🎨 Styling

- Fixed format
</blockquote>

## `gravitron`

<blockquote>

## [0.5.0] - 2025-03-06

### 🚀 Features

- Added global transform
- Made buffer memory copy and clone
- Added config system

### 🐛 Bug Fixes

- Plugin cleanup not being called

### 🚜 Refactor

- Moved general components to own crate
- Added back texture adding
- Renamed ids to handles

### ⚙️ Miscellaneous Tasks

- Updated test main
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).