### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2025-04-28
+
+### 🚀 Features
+
+- Added global transform
+- Made buffer memory copy and clone
+- Added config system
+
+### 🐛 Bug Fixes
+
+- Plugin cleanup not being called
+
+### 🚜 Refactor
+
+- Moved general components to own crate
+- Added back texture adding
+- Renamed ids to handles
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated test main
+
+
 ## [0.4.0] - 2025-01-21
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,10 +31,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -59,7 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cc",
  "cesu8",
  "jni",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e335041290c43101ca215eed6f43ec437eb5a42125573f600fc3fa42b9bddd62"
+checksum = "98922d6a4cfbcb08820c69d8eeccc05bb1f29bfa06b4f5b1dbfe9a868bd7608e"
 dependencies = [
  "arrayvec",
 ]
@@ -239,9 +239,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitstream-io"
@@ -266,27 +266,21 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder-lite"
@@ -296,9 +290,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "calloop"
@@ -306,7 +300,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "log",
  "polling",
  "rustix",
@@ -334,9 +328,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "jobserver",
  "libc",
@@ -400,18 +394,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -425,9 +419,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.52"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
@@ -599,9 +593,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "cursor-icon"
@@ -638,9 +632,9 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
@@ -667,15 +661,15 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -692,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -739,13 +733,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -768,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "env_logger",
  "glam",
@@ -794,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "gravitron_ecs_macros",
@@ -805,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_ecs_macros"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "gravitron_macro_utils",
  "proc-macro2",
@@ -815,14 +821,14 @@ dependencies = [
 
 [[package]]
 name = "gravitron_hierarchy"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "gravitron_ecs",
 ]
 
 [[package]]
 name = "gravitron_macro_utils"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "syn",
  "toml_edit",
@@ -830,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_plugin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "gravitron_ecs",
  "log",
@@ -838,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "gravitron_renderer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ash",
@@ -858,14 +864,14 @@ dependencies = [
 
 [[package]]
 name = "gravitron_utils"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "gravitron_window"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "gravitron_ecs",
@@ -877,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -904,6 +910,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+
+[[package]]
 name = "image"
 version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,9 +937,9 @@ checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -946,13 +958,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -981,15 +993,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.4"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+checksum = "5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6"
 dependencies = [
  "jiff-static",
  "log",
@@ -1000,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.4"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1033,10 +1045,11 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -1052,15 +1065,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa"
+checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
 dependencies = [
  "arbitrary",
  "cc",
@@ -1082,9 +1095,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.11",
 ]
 
 [[package]]
@@ -1150,9 +1163,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1164,7 +1177,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -1312,7 +1325,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "libc",
  "objc2",
@@ -1328,7 +1341,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-core-location",
@@ -1352,7 +1365,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -1384,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
@@ -1394,7 +1407,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "dispatch",
  "libc",
@@ -1419,7 +1432,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -1431,7 +1444,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -1454,7 +1467,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -1486,7 +1499,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-core-location",
@@ -1495,15 +1508,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "orbclient"
@@ -1537,18 +1550,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1563,9 +1576,9 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -1616,7 +1629,7 @@ checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "pin-project-lite",
  "rustix",
  "tracing",
@@ -1640,11 +1653,11 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -1655,9 +1668,9 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
@@ -1698,9 +1711,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]
@@ -1713,6 +1726,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -1741,7 +1760,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1781,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "ravif"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2413fd96bd0ea5cdeeb37eaf446a22e6ed7b981d792828721e74ded1980a45c6"
+checksum = "d6a5f31fcf7500f9401fea858ea4ab5525c99f2322cfcee732c0e6c74208c0c6"
 dependencies = [
  "avif-serialize",
  "imgref",
@@ -1843,11 +1862,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1902,11 +1921,11 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1915,15 +1934,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1955,18 +1974,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1975,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -2047,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -2057,7 +2076,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -2093,9 +2112,9 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2198,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "900f6c86a685850b1bc9f6223b20125115ee3f31e01207d81655bbcc0aea9231"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2227,15 +2246,8 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
  "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28391a4201ba7eb1984cfeb6862c0b3ea2cfe23332298967c749dddc0d6cd976"
 
 [[package]]
 name = "tracing"
@@ -2261,9 +2273,9 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2327,6 +2339,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2401,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
+checksum = "b7208998eaa3870dad37ec8836979581506e0c5c64c20c9e79e9d2a10d6f47bf"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -2415,11 +2436,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.7"
+version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
+checksum = "c2120de3d33638aaef5b9f4472bff75f07c56379cf76ea320bd3a3d65ecaf73f"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -2431,16 +2452,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cursor-icon",
  "wayland-backend",
 ]
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.7"
+version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b08bc3aafdb0035e7fe0fdf17ba0c09c268732707dca4ae098f60cb28c9e4c"
+checksum = "a93029cbb6650748881a00e4922b076092a6a08c11e7fbdb923f064b23968c5d"
 dependencies = [
  "rustix",
  "wayland-client",
@@ -2449,11 +2470,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.5"
+version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd0ade57c4e6e9a8952741325c30bf82f4246885dca8bf561898b86d0c1f58e"
+checksum = "0781cf46869b37e36928f7b432273c0995aa8aed9552c556fb18754420541efc"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -2461,11 +2482,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b31cab548ee68c7eb155517f2212049dc151f7cd7910c2b66abfd31c3ee12bd"
+checksum = "7ccaacc76703fefd6763022ac565b590fcade92202492381c95b2edfdf7d46b3"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -2474,11 +2495,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782e12f6cd923c3c316130d56205ebab53f55d6666b7faddfad36cecaeeb4022"
+checksum = "248a02e6f595aad796561fa82d25601bd2c8c3b145b1c7453fc8f94c1a58f8b2"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -2487,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.5"
+version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
+checksum = "896fdafd5d28145fce7958917d69f2fd44469b1d4e861cb5961bcbeebc6d1484"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -2498,9 +2519,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.5"
+version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09"
+checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
 dependencies = [
  "dlib",
  "log",
@@ -2751,7 +2772,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "bytemuck",
  "calloop",
@@ -2804,6 +2825,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,7 +2877,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "dlib",
  "log",
  "once_cell",
@@ -2872,8 +2902,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -2881,6 +2919,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,18 @@ glam = "0.29.3"
 thiserror = "2.0.12"
 ash = "0.38.0"
 winit = { version = "0.30.9", features = ["wayland"] }
-gravitron_utils = { path = "./crates/gravitron_utils", version = "0.1.4" }
-gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.4.0" }
-gravitron_hierarchy = { path = "./crates/gravitron_hierarchy", version = "0.1.0" }
-gravitron_renderer = { path = "./crates/gravitron_renderer", version = "0.1.0" }
-gravitron_macro_utils = { path = "./crates/gravitron_macro_utils", version = "0.1.2" }
-gravitron_plugin = { path = "./crates/gravitron_plugin", version = "0.1.0" }
-gravitron_window = { path = "./crates/gravitron_window", version = "0.1.0" }
+gravitron_utils = { path = "./crates/gravitron_utils", version = "0.1.5" }
+gravitron_ecs = { path = "./crates/gravitron_ecs", version = "0.4.1" }
+gravitron_hierarchy = { path = "./crates/gravitron_hierarchy", version = "0.2.0" }
+gravitron_renderer = { path = "./crates/gravitron_renderer", version = "0.2.0" }
+gravitron_macro_utils = { path = "./crates/gravitron_macro_utils", version = "0.1.3" }
+gravitron_plugin = { path = "./crates/gravitron_plugin", version = "0.2.0" }
+gravitron_window = { path = "./crates/gravitron_window", version = "0.1.1" }
 gravitron_components = { path = "./crates/gravitron_components", version = "0.1.0" }
 
 [package]
 name = "gravitron"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A GameEngine based on an ECS and Vulkan"

--- a/crates/gravitron_components/CHANGELOG.md
+++ b/crates/gravitron_components/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2025-04-28
+
+### 🚜 Refactor
+
+- Moved general components to own crate
+
+

--- a/crates/gravitron_ecs/CHANGELOG.md
+++ b/crates/gravitron_ecs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] - 2025-04-28
+
+### 🚀 Features
+
+- Added global transform
+
+
 ## [0.4.0] - 2025-01-21
 
 ### 🚀 Features

--- a/crates/gravitron_ecs/Cargo.toml
+++ b/crates/gravitron_ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]
@@ -11,7 +11,7 @@ exclude = ["CHANGELOG.md"]
 readme = "README.md"
 
 [dependencies]
-gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.5" }
+gravitron_ecs_macros = { path = "./gravitron_ecs_macros" , version = "0.1.6" }
 gravitron_utils = { workspace = true }
 log = { workspace = true }
 rustc-hash = "2.1.1"

--- a/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.6] - 2025-04-28
+
+### ⚙️ Miscellaneous Tasks
+
+- Update Cargo.toml dependencies
+
+
 ## [0.1.5] - 2025-01-21
 
 ### 🚀 Features

--- a/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
+++ b/crates/gravitron_ecs/gravitron_ecs_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_ecs_macros"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "gravitron"]

--- a/crates/gravitron_hierarchy/CHANGELOG.md
+++ b/crates/gravitron_hierarchy/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2025-04-28
+
+### 🚀 Features
+
+- Simplified propagation query and added an update only variant
+
+### 🐛 Bug Fixes
+
+- Propagation query not updating entities without children
+
+### 🧪 Testing
+
+- *(hierarchy)* Fixed tests
+
+
 ## [0.1.0] - 2025-01-21
 
 ### 🚀 Features

--- a/crates/gravitron_hierarchy/Cargo.toml
+++ b/crates/gravitron_hierarchy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_hierarchy"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]

--- a/crates/gravitron_macro_utils/CHANGELOG.md
+++ b/crates/gravitron_macro_utils/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
+
 ## [0.1.2] - 2025-01-21
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/gravitron_macro_utils/Cargo.toml
+++ b/crates/gravitron_macro_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_macro_utils"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]

--- a/crates/gravitron_plugin/CHANGELOG.md
+++ b/crates/gravitron_plugin/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2025-04-28
+
+### 🚀 Features
+
+- Added plugin dependencies
+- Added config system
+
+### 🐛 Bug Fixes
+
+- Plugin cleanup not being called
+- Tick not updated
+- Test main errors
+- Descriptor updates invalid
+
+### 🚜 Refactor
+
+- Removed unused parts of vulkan config
+
+### ⚙️ Miscellaneous Tasks
+
+- Added some more logging
+
+
 ## [0.1.0] - 2025-01-21
 
 ### 🚀 Features

--- a/crates/gravitron_plugin/Cargo.toml
+++ b/crates/gravitron_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_plugin"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]

--- a/crates/gravitron_renderer/CHANGELOG.md
+++ b/crates/gravitron_renderer/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2025-04-28
+
+### 🚀 Features
+
+- Added global transform
+- Added plugin dependencies
+- Added model manager resource
+- Added inline
+- Added descriptor rewrite
+- Made buffer memory copy and clone
+- Added config system
+- Added renderer logging
+
+### 🐛 Bug Fixes
+
+- Plugin cleanup not being called
+- Fixed pipeline imports
+- Removed warnings
+- Combined default descriptor sets
+- Added command buffer rerecording
+- Added unused
+- Test main errors
+- Removed vulkan errors
+- Added subpass dependencies
+- Nothing rendering
+- Descriptor wrong binding
+- Removed cache bypass
+- Descriptor updates invalid
+- Descriptor updates every frame
+- Simple buffer resize not working
+
+### 🚜 Refactor
+
+- Removed matrix from transform
+- Moved general components to own crate
+- Made memory manager return type result
+- Separated vulkan resources
+- Moved model code out of graphics
+- Moved renderer
+- Added descriptor manager and graphics pipeline
+- Updated pipeline manager
+- Updated renderer
+- Added all resources to plugin
+- Removed unused allow
+- Added lights update
+- Added back texture adding
+- Renamed ids to handles
+
+### 🎨 Styling
+
+- Fixed format
+
+
 ## [0.1.0] - 2025-01-21
 
 ### 🚀 Features

--- a/crates/gravitron_renderer/Cargo.toml
+++ b/crates/gravitron_renderer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_renderer"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]

--- a/crates/gravitron_utils/CHANGELOG.md
+++ b/crates/gravitron_utils/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.5] - 2025-04-28
+
+### ⚙️ Miscellaneous Tasks
+
+- Update Cargo.toml dependencies
+
+
 ## [0.1.4] - 2025-01-21
 
 ### ⚙️ Miscellaneous Tasks

--- a/crates/gravitron_utils/Cargo.toml
+++ b/crates/gravitron_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_utils"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]

--- a/crates/gravitron_window/CHANGELOG.md
+++ b/crates/gravitron_window/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2025-04-28
+
+### 🚀 Features
+
+- Added global transform
+- Added config system
+
+### ⚙️ Miscellaneous Tasks
+
+- Added some more logging
+
+
 ## [0.1.0] - 2025-01-21
 
 ### 🚀 Features

--- a/crates/gravitron_window/Cargo.toml
+++ b/crates/gravitron_window/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gravitron_window"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["game", "gravitron"]


### PR DESCRIPTION



## 🤖 New release

* `gravitron_macro_utils`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `gravitron_ecs_macros`: 0.1.5 -> 0.1.6
* `gravitron_utils`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `gravitron_ecs`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `gravitron_hierarchy`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `gravitron_plugin`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `gravitron_components`: 0.1.0
* `gravitron_window`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `gravitron_renderer`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `gravitron`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `gravitron_hierarchy` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/method_parameter_count_changed.ron

Failed in:
  gravitron_hierarchy::propagation::PropagationQuery::propagate now takes 2 parameters instead of 6, in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_hierarchy/src/propagation.rs:41

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  gravitron_hierarchy::propagation::PropagationQuery::propagate takes 0 generic types instead of 4, in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_hierarchy/src/propagation.rs:41
```

### ⚠ `gravitron_plugin` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AppConfig.version in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_plugin/src/config.rs:2
  field AppConfig.fps in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_plugin/src/config.rs:3
  field AppConfig.parallel_systems in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_plugin/src/config.rs:4

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_missing.ron

Failed in:
  enum gravitron_plugin::config::vulkan::ImageData, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/vulkan.rs:46
  enum gravitron_plugin::config::vulkan::PipelineType, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/vulkan.rs:83
  enum gravitron_plugin::config::vulkan::DescriptorType, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/vulkan.rs:155

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant MainSystemStage::RenderRecording 2 -> 3 in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_plugin/src/stages.rs:6
  variant MainSystemStage::RenderExecute 3 -> 4 in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_plugin/src/stages.rs:7
  variant MainSystemStage::PostRender 4 -> 5 in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_plugin/src/stages.rs:8

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant MainSystemStage:RenderPrepare in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_plugin/src/stages.rs:5

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/inherent_method_missing.ron

Failed in:
  AppConfig::set_window_config, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/mod.rs:16
  AppConfig::set_vulkan_config, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/mod.rs:21
  AppConfig::set_engine_config, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/mod.rs:26
  PluginManager::run, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/manager.rs:45

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  gravitron_plugin::app::AppBuilder::config takes 1 generic types instead of 0, in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_plugin/src/app.rs:179
  gravitron_plugin::app::AppBuilder::config_mut takes 1 generic types instead of 0, in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_plugin/src/app.rs:208

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/module_missing.ron

Failed in:
  mod gravitron_plugin::config::engine, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/engine.rs:1
  mod gravitron_plugin::config::vulkan, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/vulkan.rs:1
  mod gravitron_plugin::config::window, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/window.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct gravitron_plugin::config::window::WindowConfig, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/window.rs:2
  struct gravitron_plugin::config::vulkan::BufferDescriptor, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/vulkan.rs:183
  struct gravitron_plugin::config::vulkan::ComputePipelineConfig, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/vulkan.rs:123
  struct gravitron_plugin::config::vulkan::GraphicsPipelineConfig, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/vulkan.rs:89
  struct gravitron_plugin::config::vulkan::ImageConfig, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/vulkan.rs:40
  struct gravitron_plugin::config::vulkan::ImageDescriptor, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/vulkan.rs:211
  struct gravitron_plugin::config::vulkan::DescriptorSet, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/vulkan.rs:150
  struct gravitron_plugin::config::vulkan::VulkanConfig, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/vulkan.rs:6
  struct gravitron_plugin::config::engine::EngineConfig, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/engine.rs:1
  struct gravitron_plugin::config::vulkan::RendererConfig, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/vulkan.rs:68

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field window of struct AppConfig, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/mod.rs:10
  field vulkan of struct AppConfig, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/mod.rs:11
  field engine of struct AppConfig, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/config/mod.rs:12

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/trait_method_missing.ron

Failed in:
  method name of trait Plugin, previously in file /tmp/.tmpCVwo5y/gravitron_plugin/src/lib.rs:13

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  MainSystemStage::RenderRecording moved from position 3 to 4, in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_plugin/src/stages.rs:6
  MainSystemStage::RenderExecute moved from position 4 to 5, in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_plugin/src/stages.rs:7
  MainSystemStage::PostRender moved from position 5 to 6, in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_plugin/src/stages.rs:8
```

### ⚠ `gravitron_renderer` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_missing.ron

Failed in:
  enum gravitron_renderer::memory::types::ImageType, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/types.rs:37
  enum gravitron_renderer::memory::types::BufferType, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/types.rs:32
  enum gravitron_renderer::error::RendererInitError, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/error.rs:14
  enum gravitron_renderer::memory::types::BufferBlockSize, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/types.rs:25
  enum gravitron_renderer::error::QueueFamilyMissingError, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/error.rs:4
  enum gravitron_renderer::memory::types::ImageId, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/types.rs:16
  enum gravitron_renderer::memory::types::BufferId, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/types.rs:10
  enum gravitron_renderer::graphics::resources::model::InstanceCount, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/model/mod.rs:57

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/method_parameter_count_changed.ron

Failed in:
  gravitron_renderer::ecs::components::camera::CameraBuilder::build now takes 1 parameters instead of 2, in /tmp/.tmpeUs5bP/gravitron/crates/gravitron_renderer/src/ecs/components/camera.rs:43

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/module_missing.ron

Failed in:
  mod gravitron_renderer::graphics::swapchain, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/swapchain.rs:1
  mod gravitron_renderer::memory::types, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/types.rs:1
  mod gravitron_renderer::graphics::resources::model, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/model/mod.rs:1
  mod gravitron_renderer::memory, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/mod.rs:1
  mod gravitron_renderer::error, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/error.rs:1
  mod gravitron_renderer::graphics::resources, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/mod.rs:1
  mod gravitron_renderer::memory::manager, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/manager.rs:1
  mod gravitron_renderer::graphics::resources::lighting, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/lighting.rs:1
  mod gravitron_renderer::ecs::resources::vulkan, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/ecs/resources/vulkan.rs:1
  mod gravitron_renderer::graphics::resources::material, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/material.rs:1
  mod gravitron_renderer::ecs::components::transform, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/ecs/components/transform.rs:1
  mod gravitron_renderer::graphics, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/mod.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  BUFFER_BLOCK_SIZE_MEDIUM in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/types.rs:22
  BUFFER_BLOCK_SIZE_SMALL in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/types.rs:23
  CUBE_MODEL in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/model/mod.rs:24
  BUFFER_BLOCK_SIZE_LARGE in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/types.rs:21
  IMAGES_PER_FRAME_BUFFER in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/swapchain.rs:15
  PLANE_MODEL in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/model/mod.rs:25

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct gravitron_renderer::graphics::resources::lighting::SpotLight, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/lighting.rs:29
  struct gravitron_renderer::graphics::Renderer, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/mod.rs:30
  struct gravitron_renderer::graphics::resources::material::Material, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/material.rs:1
  struct gravitron_renderer::graphics::resources::lighting::LightInfo, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/lighting.rs:4
  struct gravitron_renderer::graphics::resources::model::VertexData, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/model/mod.rs:40
  struct gravitron_renderer::graphics::resources::lighting::DirectionalLight, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/lighting.rs:12
  struct gravitron_renderer::graphics::resources::model::ModelId, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/model/mod.rs:28
  struct gravitron_renderer::graphics::resources::model::Model, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/model/mod.rs:30
  struct gravitron_renderer::memory::manager::MemoryManager, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/manager.rs:26
  struct gravitron_renderer::graphics::resources::lighting::PointLight, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/lighting.rs:21
  struct gravitron_renderer::graphics::resources::lighting::Vec3Align16, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/lighting.rs:40
  struct gravitron_renderer::memory::BufferMemory, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/allocator.rs:5
  struct gravitron_renderer::ecs::resources::vulkan::Vulkan, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/ecs/resources/vulkan.rs:24
  struct gravitron_renderer::graphics::resources::model::ModelManager, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/model/mod.rs:16
  struct gravitron_renderer::ecs::components::transform::Transform, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/ecs/components/transform.rs:4
  struct gravitron_renderer::memory::manager::Transfer, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/memory/manager.rs:382
  struct gravitron_renderer::graphics::resources::model::InstanceData, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/resources/model/mod.rs:48
  struct gravitron_renderer::graphics::swapchain::SwapChain, previously in file /tmp/.tmpCVwo5y/gravitron_renderer/src/graphics/swapchain.rs:17
```

### ⚠ `gravitron` breaking changes

```text
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/module_missing.ron

Failed in:
  mod gravitron::renderer, previously in file /tmp/.tmpCVwo5y/gravitron/src/lib.rs:11
  mod gravitron::ecs::resources, previously in file /tmp/.tmpCVwo5y/gravitron/src/ecs/resources.rs:1
  mod gravitron::ecs::components, previously in file /tmp/.tmpCVwo5y/gravitron/src/ecs/components.rs:1
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `gravitron_macro_utils`

<blockquote>

## [0.1.2] - 2025-01-21

### ⚙️ Miscellaneous Tasks

- Moved some dependencies to workspace
</blockquote>

## `gravitron_ecs_macros`

<blockquote>

## [0.1.6] - 2025-04-28

### ⚙️ Miscellaneous Tasks

- Update Cargo.toml dependencies
</blockquote>

## `gravitron_utils`

<blockquote>

## [0.1.5] - 2025-04-28

### ⚙️ Miscellaneous Tasks

- Update Cargo.toml dependencies
</blockquote>

## `gravitron_ecs`

<blockquote>

## [0.4.1] - 2025-04-28

### 🚀 Features

- Added global transform
</blockquote>

## `gravitron_hierarchy`

<blockquote>

## [0.2.0] - 2025-04-28

### 🚀 Features

- Simplified propagation query and added an update only variant

### 🐛 Bug Fixes

- Propagation query not updating entities without children

### 🧪 Testing

- *(hierarchy)* Fixed tests
</blockquote>

## `gravitron_plugin`

<blockquote>

## [0.2.0] - 2025-04-28

### 🚀 Features

- Added plugin dependencies
- Added config system

### 🐛 Bug Fixes

- Plugin cleanup not being called
- Tick not updated
- Test main errors
- Descriptor updates invalid

### 🚜 Refactor

- Removed unused parts of vulkan config

### ⚙️ Miscellaneous Tasks

- Added some more logging
</blockquote>

## `gravitron_components`

<blockquote>

## [0.1.0] - 2025-04-28

### 🚜 Refactor

- Moved general components to own crate
</blockquote>

## `gravitron_window`

<blockquote>

## [0.1.1] - 2025-04-28

### 🚀 Features

- Added global transform
- Added config system

### ⚙️ Miscellaneous Tasks

- Added some more logging
</blockquote>

## `gravitron_renderer`

<blockquote>

## [0.2.0] - 2025-04-28

### 🚀 Features

- Added global transform
- Added plugin dependencies
- Added model manager resource
- Added inline
- Added descriptor rewrite
- Made buffer memory copy and clone
- Added config system
- Added renderer logging

### 🐛 Bug Fixes

- Plugin cleanup not being called
- Fixed pipeline imports
- Removed warnings
- Combined default descriptor sets
- Added command buffer rerecording
- Added unused
- Test main errors
- Removed vulkan errors
- Added subpass dependencies
- Nothing rendering
- Descriptor wrong binding
- Removed cache bypass
- Descriptor updates invalid
- Descriptor updates every frame
- Simple buffer resize not working

### 🚜 Refactor

- Removed matrix from transform
- Moved general components to own crate
- Made memory manager return type result
- Separated vulkan resources
- Moved model code out of graphics
- Moved renderer
- Added descriptor manager and graphics pipeline
- Updated pipeline manager
- Updated renderer
- Added all resources to plugin
- Removed unused allow
- Added lights update
- Added back texture adding
- Renamed ids to handles

### 🎨 Styling

- Fixed format
</blockquote>

## `gravitron`

<blockquote>

## [0.5.0] - 2025-04-28

### 🚀 Features

- Added global transform
- Made buffer memory copy and clone
- Added config system

### 🐛 Bug Fixes

- Plugin cleanup not being called

### 🚜 Refactor

- Moved general components to own crate
- Added back texture adding
- Renamed ids to handles

### ⚙️ Miscellaneous Tasks

- Updated test main
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).